### PR TITLE
Support exporting model as MXNet model (sym, params).

### DIFF
--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -4398,7 +4398,7 @@ def get_model():
             self._module = None
 
             # Create Module for Inference
-            self._compiled = False
+            self.compiled = False
             self._create_predict_module()
 
         def compile(self, optimizer, loss, metrics=None, loss_weights=None,
@@ -4479,7 +4479,7 @@ def get_model():
                 context=self._context,
                 fixed_param_names=self._fixed_weights)
             set_model(self)
-            self._compiled = True
+            self.compiled = True
 
         def _adjust_module(self, inputs, phase):
             if not self._module:
@@ -4505,7 +4505,7 @@ def get_model():
 
             if not self._module.binded:
                 # allow prediction without compiling the model using different binding
-                if not self._compiled and phase == 'pred':
+                if not self.compiled and phase == 'pred':
                     self._module.bind(data_shapes=data_shapes, label_shapes=None,
                                       for_training=False)
                     self._set_weights()
@@ -4590,7 +4590,7 @@ def get_model():
         def _make_predict_function(self):
             def predict_function(inputs):
                 # used predict only module if predict is called without compile
-                if not self._compiled:
+                if not self.compiled:
                     self._module = self._predict_only_module
                     set_model(self)
 

--- a/keras/models.py
+++ b/keras/models.py
@@ -71,9 +71,17 @@ def save_mxnet_model(model, prefix, epoch=0):
         data_names, data_shapes
     """
     assert model is not None, 'MXNet Backend: Invalid state. Model cannot be None.'
-    assert model.model is not None, 'MXNet Backend: Invalid state. MXNet Model cannot be None.'
 
-    mxnet_model = model.model
+    # Handle Sequential Model / Functional API Model Case
+    if isinstance(model, Sequential):
+        mxnet_model = model.model
+    elif isinstance(model, Model):
+        mxnet_model = model
+    else:
+        raise ValueError('MXNet Backend: Invalid model type. Supported Models - Sequential, Model.')
+
+    assert mxnet_model is not None, 'MXNet Backend: Invalid state. MXNet Model cannot be None.'
+
     if not mxnet_model.compiled:
         raise ValueError('MXNet Backend: Model is not compiled. Cannot save the MXNet model!')
 

--- a/keras/models.py
+++ b/keras/models.py
@@ -66,6 +66,9 @@ def save_mxnet_model(model, prefix, epoch=0):
                 Model will be saved as '<prefix>-symbol.json' and '<prefix>-<epoch>.params'.
         epoch: (Optional) Tag the params file with epoch of the model being saved. Default is 0.
                Model params file is saved as '<prefix>-<epoch>.params' or '<prefix>-0000.params' by default.
+
+    # Returns
+        data_names, data_shapes
     """
     assert model is not None, "MXNet Backend: Invalid state. Model cannot be None."
     assert model.model is not None, "MXNet Backend: Invalid state. MXNet Model cannot be None."
@@ -98,6 +101,7 @@ def save_mxnet_model(model, prefix, epoch=0):
           "the batch_size used for model training. ")
     print("You can change the batch_size for binding the module based on your inference batch_size.")
 
+    return data_names, data_shapes
 
 def save_model(model, filepath, overwrite=True, include_optimizer=True):
     """Save a model to a HDF5 file.

--- a/keras/models.py
+++ b/keras/models.py
@@ -70,19 +70,19 @@ def save_mxnet_model(model, prefix, epoch=0):
     # Returns
         data_names, data_shapes
     """
-    assert model is not None, "MXNet Backend: Invalid state. Model cannot be None."
-    assert model.model is not None, "MXNet Backend: Invalid state. MXNet Model cannot be None."
+    assert model is not None, 'MXNet Backend: Invalid state. Model cannot be None.'
+    assert model.model is not None, 'MXNet Backend: Invalid state. MXNet Model cannot be None.'
 
     mxnet_model = model.model
     if not mxnet_model.compiled:
-        raise ValueError("MXNet Backend: Model is not compiled. Cannot save the MXNet model!")
+        raise ValueError('MXNet Backend: Model is not compiled. Cannot save the MXNet model!')
 
     # Saving MXNet model for Inference in native MXNet engine.
     symbol = mxnet_model._pred_mxnet_symbol
     module = mxnet_model._module
 
-    assert symbol is not None, "MXNet Backend: Invalid state. MXNet Symbol cannot be None."
-    assert module is not None, "MXNet Backend: Invalid state. MXNet Module cannot be None."
+    assert symbol is not None, 'MXNet Backend: Invalid state. MXNet Symbol cannot be None.'
+    assert module is not None, 'MXNet Backend: Invalid state. MXNet Module cannot be None.'
 
     # Get Module Input data_names and data_shapes.
     # This info will be useful for users to easily bind the exported model in MXNet.
@@ -90,18 +90,19 @@ def save_mxnet_model(model, prefix, epoch=0):
     data_names = pred_module.data_names
     data_shapes = pred_module.data_shapes
 
-    symbol.save('%s-symbol.json' % format(prefix))
-    module.save_params('%s-%04d.params' % format(prefix, epoch))
+    symbol.save('%s-symbol.json' % prefix)
+    module.save_params('%s-%04d.params' % (prefix, epoch))
 
-    print("MXNet Backend: Successfully exported the model as MXNet model!\n\n")
-    print("Model input data_names and data_shapes are: ")
-    print("data_names : ", data_names)
-    print("data_shapes : ", data_shapes)
-    print("\n\nNote: In the above data_shapes, the first dimension represent "
-          "the batch_size used for model training. ")
-    print("You can change the batch_size for binding the module based on your inference batch_size.")
+    print('MXNet Backend: Successfully exported the model as MXNet model!')
+    print('\n\nModel input data_names and data_shapes are: ')
+    print('data_names : ', data_names)
+    print('data_shapes : ', data_shapes)
+    print('\n\nNote: In the above data_shapes, the first dimension represent '
+          'the batch_size used for model training. ')
+    print('You can change the batch_size for binding the module based on your inference batch_size.')
 
     return data_names, data_shapes
+
 
 def save_model(model, filepath, overwrite=True, include_optimizer=True):
     """Save a model to a HDF5 file.

--- a/keras/models.py
+++ b/keras/models.py
@@ -32,6 +32,73 @@ except ImportError:
     h5py = None
 
 
+def save_mxnet_model(model, prefix, epoch=0):
+    """Save the model as MXNet model. Creates MXNet symbol and params file.
+
+    The saved model can be used to load in MXNet engine for inference. Can be used to perform
+    inference on any language bindings supported by MXNet.
+
+    Note: data_names and data_shapes required in MXNet represent input layer name and shape.
+    When you call save_mxnet_model, these information will be printed.
+    You can change the first dimension of data_shapes to match batch size for inference.
+
+    Below sample code shows how to load a Keras-MXNet pre-trained model saved with 'prefix',
+    input name as '/dense_1_input1' and inference batch size of 1 and data shape of 784.
+
+    ```python
+    >>> import mxnet as mx
+    >>> sym, arg_params, aux_params = mx.model.load_checkpoint(prefix, epoch=0)
+    ##  data_names and data_shapes will be print
+    >>> mod = mx.mod.Module(symbol=sym, data_names=['/dense_1_input1'], \
+                            context=mx.cpu(), label_names=None)
+    >>> mod.bind(for_training=False, data_shapes=[('/dense_1_input1', (1,784))], \
+                 label_shapes=mod._label_shapes)
+    >>> mod.set_params(arg_params, aux_params, allow_missing=True)
+    ##  Prepare data iterator
+    >>> data_iter = mx.io.NDArrayIter(data, label=None, batch_size=1)
+    ##  Predict
+    >>> result = mod.predict(data_iter)
+    ```
+
+    # Arguments
+        model: Keras model instance to be saved as MXNet model.
+        prefix: Prefix name of the saved Model (symbol and params) files.
+                Model will be saved as '<prefix>-symbol.json' and '<prefix>-<epoch>.params'.
+        epoch: (Optional) Tag the params file with epoch of the model being saved. Default is 0.
+               Model params file is saved as '<prefix>-<epoch>.params' or '<prefix>-0000.params' by default.
+    """
+    assert model is not None, "MXNet Backend: Invalid state. Model cannot be None."
+    assert model.model is not None, "MXNet Backend: Invalid state. MXNet Model cannot be None."
+
+    mxnet_model = model.model
+    if not mxnet_model.compiled:
+        raise ValueError("MXNet Backend: Model is not compiled. Cannot save the MXNet model!")
+
+    # Saving MXNet model for Inference in native MXNet engine.
+    symbol = mxnet_model._pred_mxnet_symbol
+    module = mxnet_model._module
+
+    assert symbol is not None, "MXNet Backend: Invalid state. MXNet Symbol cannot be None."
+    assert module is not None, "MXNet Backend: Invalid state. MXNet Module cannot be None."
+
+    # Get Module Input data_names and data_shapes.
+    # This info will be useful for users to easily bind the exported model in MXNet.
+    pred_module = module._buckets['pred']
+    data_names = pred_module.data_names
+    data_shapes = pred_module.data_shapes
+
+    symbol.save('%s-symbol.json' % format(prefix))
+    module.save_params('%s-%04d.params' % format(prefix, epoch))
+
+    print("MXNet Backend: Successfully exported the model as MXNet model!\n\n")
+    print("Model input data_names and data_shapes are: ")
+    print("data_names : ", data_names)
+    print("data_shapes : ", data_shapes)
+    print("\n\nNote: In the above data_shapes, the first dimension represent "
+          "the batch_size used for model training. ")
+    print("You can change the batch_size for binding the module based on your inference batch_size.")
+
+
 def save_model(model, filepath, overwrite=True, include_optimizer=True):
     """Save a model to a HDF5 file.
 

--- a/keras/models.py
+++ b/keras/models.py
@@ -90,10 +90,14 @@ def save_mxnet_model(model, prefix, epoch=0):
     data_names = pred_module.data_names
     data_shapes = pred_module.data_shapes
 
-    symbol.save('%s-symbol.json' % prefix)
-    module.save_params('%s-%04d.params' % (prefix, epoch))
+    symbol_fname = '%s-symbol.json' % prefix
+    params_fname = '%s-%04d.params' % (prefix, epoch)
+    symbol.save(symbol_fname)
+    module.save_params(params_fname)
 
     print('MXNet Backend: Successfully exported the model as MXNet model!')
+    print('MXNet symbol file - ', symbol_fname)
+    print('MXNet params file - ', params_fname)
     print('\n\nModel input data_names and data_shapes are: ')
     print('data_names : ', data_names)
     print('data_shapes : ', data_shapes)

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_raises
 
 from keras import backend as K
 from keras.models import Model, Sequential
-from keras.layers import Dense, Lambda, RepeatVector, TimeDistributed, LSTM
+from keras.layers import Dense, Lambda, RepeatVector, TimeDistributed, LSTM, Embedding
 from keras.layers import Conv2D, Flatten
 from keras.layers import Input
 from keras import optimizers
@@ -618,6 +618,44 @@ def test_saving_recurrent_layer_without_bias():
 @pytest.mark.skipif((K.backend() != 'mxnet'),
                     reason='Supported for MXNet backend only.')
 @keras_test
+def test_sequential_lstm_mxnet_model_saving():
+    max_features = 1000
+    maxlen = 80
+    batch_size = 32
+
+    model = Sequential()
+    model.add(Embedding(max_features, 128, input_length=maxlen))
+    model.add(LSTM(128, unroll=True))
+
+    model.compile(loss='binary_crossentropy',
+                  optimizer='adam',
+                  metrics=['accuracy'])
+
+    # Generate random data
+    x = np.random.random((1000, maxlen))
+    y = np.random.random((1000, 128))
+    print("X shape - ", x.shape)
+    print("Y shape - ", y.shape)
+    model.fit(x, y, batch_size=batch_size, epochs=2)
+
+    save_mxnet_model(model, prefix='test_lstm', epoch=0)
+
+    # Import with MXNet and try to perform inference
+    import mxnet as mx
+    sym, arg_params, aux_params = mx.model.load_checkpoint(prefix='test_lstm', epoch=0)
+    mod = mx.mod.Module(symbol=sym, data_names=['/embedding_1_input1'], context=mx.cpu(), label_names=None)
+    mod.bind(for_training=False, data_shapes=[('/embedding_1_input1', (1, 80))], label_shapes=mod._label_shapes)
+    mod.set_params(arg_params, aux_params, allow_missing=True)
+    data_iter = mx.io.NDArrayIter([mx.nd.random.normal(shape=(1, 80))], label=None, batch_size=1)
+    mod.predict(data_iter)
+
+    os.remove('test_lstm-symbol.json')
+    os.remove('test_lstm-0000.params')
+
+
+@pytest.mark.skipif((K.backend() != 'mxnet'),
+                    reason='Supported for MXNet backend only.')
+@keras_test
 def test_sequential_mxnet_model_saving():
     model = Sequential()
     model.add(Dense(2, input_shape=(3,)))
@@ -637,12 +675,11 @@ def test_sequential_mxnet_model_saving():
     import mxnet as mx
     sym, arg_params, aux_params = mx.model.load_checkpoint(prefix='test', epoch=0)
     mod = mx.mod.Module(symbol=sym, data_names=['/dense_1_input1'], context=mx.cpu(), label_names=None)
-    mod.bind(for_training=False, data_shapes=[('/dense_1_input1', (1,3))], label_shapes=mod._label_shapes)
+    mod.bind(for_training=False, data_shapes=[('/dense_1_input1', (1, 3))], label_shapes=mod._label_shapes)
     mod.set_params(arg_params, aux_params, allow_missing=True)
     data_iter = mx.io.NDArrayIter([mx.nd.random.normal(shape=(1, 3))], label=None, batch_size=1)
-    result = mod.predict(data_iter)
+    mod.predict(data_iter)
 
-    print('RESULT - ', result)
     os.remove('test-symbol.json')
     os.remove('test-0000.params')
 

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -15,7 +15,7 @@ from keras import optimizers
 from keras import losses
 from keras import metrics
 from keras.utils.test_utils import keras_test
-from keras.models import save_model, load_model
+from keras.models import save_model, load_model, save_mxnet_model
 
 
 @keras_test
@@ -491,8 +491,6 @@ def test_saving_custom_activation_function():
     assert_allclose(out, out2, atol=1e-05)
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support LSTM yet.')
 @keras_test
 def test_saving_model_with_long_layer_names():
     # This layer name will make the `layers_name` HDF5 attribute blow
@@ -601,8 +599,6 @@ def test_saving_recurrent_layer_with_init_state():
     os.remove(fname)
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support LSTM yet.')
 @keras_test
 def test_saving_recurrent_layer_without_bias():
     vector_size = 8
@@ -617,6 +613,50 @@ def test_saving_recurrent_layer_without_bias():
 
     loaded_model = load_model(fname)
     os.remove(fname)
+
+
+@pytest.mark.skipif((K.backend() != 'mxnet'),
+                    reason='Supported for MXNet backend only.')
+@keras_test
+def test_sequential_mxnet_model_saving():
+    model = Sequential()
+    model.add(Dense(2, input_shape=(3,)))
+    model.add(RepeatVector(3))
+    model.add(TimeDistributed(Dense(3)))
+    model.compile(loss=losses.MSE,
+                  optimizer=optimizers.RMSprop(lr=0.0001),
+                  metrics=[metrics.categorical_accuracy],
+                  sample_weight_mode='temporal')
+    x = np.random.random((1, 3))
+    y = np.random.random((1, 3, 3))
+    model.train_on_batch(x, y)
+
+    save_mxnet_model(model, prefix='test', epoch=0)
+
+    # Import with MXNet and try to perform inference
+    import mxnet as mx
+    sym, arg_params, aux_params = mx.model.load_checkpoint(prefix='test', epoch=0)
+    mod = mx.mod.Module(symbol=sym, data_names=['/dense_1_input1'], context=mx.cpu(), label_names=None)
+    mod.bind(for_training=False, data_shapes=[('/dense_1_input1', (1,3))], label_shapes=mod._label_shapes)
+    mod.set_params(arg_params, aux_params, allow_missing=True)
+    data_iter = mx.io.NDArrayIter([mx.nd.random.normal(shape=(1, 3))], label=None, batch_size=1)
+    result = mod.predict(data_iter)
+
+    print('RESULT - ', result)
+    os.remove('test-symbol.json')
+    os.remove('test-0000.params')
+
+
+@pytest.mark.skipif((K.backend() != 'mxnet'),
+                    reason='Supported for MXNet backend only.')
+@keras_test
+def test_sequential_mxnet_model_saving_no_compile():
+    model = Sequential()
+    model.add(Dense(2, input_shape=(3,)))
+    model.add(RepeatVector(3))
+    model.add(TimeDistributed(Dense(3)))
+    with pytest.raises(AssertionError):
+        save_mxnet_model(model, prefix='test', epoch=0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adding support to save the model as MXNet model (sym, params). This allows users to train using Keras interface with MXNet backend, export the model as MXNet model, use native MXNet for inference. Users can also use any language binding of MXNet ex: Python/Scala/C++ for inference.

## Testing Done
1. Train MLP Sequential Model for MNIST and infer with MXNet.
2. Train Resnet50_CIFAR10 Functional Model on Multi-GpU and infer with MXNet on CPU.
3. Train IMDB_LSTM Sequential Model and infer with MXNet.

@nswamy @roywei @kalyc