### PR TITLE
Fix crashing softmax mxnet backend operator on GPUs

### DIFF
--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -2809,7 +2809,7 @@ def softmax(x):
     # Returns
         A tensor.
     """
-    return KerasSymbol(mx.sym.SoftmaxActivation(data=x.symbol))
+    return KerasSymbol(mx.sym.softmax(data=x.symbol))
 
 
 @keras_mxnet_symbol


### PR DESCRIPTION
* mx.sym.SoftmaxActivation operator crashes on GPUs - https://github.com/apache/incubator-mxnet/issues/9823. This issue is visible in mxnet v1.2.0 but not in earlier version.
* Move to mx.sym.softmax() operator that has the fix for softmax operator.
* Without this fix, with latest mxnet v1.2.0, none of the CNNs work.
* Verified on CPU and GPUs
@roywei @kalyc 