### PR TITLE
Adding get_mxnet_model_info API to allow users to query underlying MXNet model info

### DIFF
--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -3076,6 +3076,10 @@ def conv1d(x, kernel, strides=1, padding='valid',
         # X original shape (batch, length, input_dim)
         # Add a dimension to X to Make it (batch, length, 1, input_dim)
         x = expand_dims(x, axis=2)
+        # Add dimension to kernel
+        # for channels last: kernel_shape = kernel_size + (input_dim, filters)
+        # it will become: (kernel_size, 1, input_dim, filters)
+        kernel = expand_dims(kernel, axis=1)
         # update x._keras_shape
         if shape is not None:
             x._keras_shape = (shape[0], shape[1], 1, shape[2])
@@ -3083,15 +3087,16 @@ def conv1d(x, kernel, strides=1, padding='valid',
         # X original shape (batch, input_dim, length)
         # Add a dimension to X to make it (batch, input_dim, length, 1)
         x = expand_dims(x, axis=3)
+        # Add dimension to kernel
+        # for channels first: kernel_shape = (filters, input_dim) + kernel_size
+        # it will become: (filters, input_dim, kernel_size, 1)
+        kernel = expand_dims(kernel, axis=3)
         if shape is not None:
             x._keras_shape = (shape[0], shape[1], shape[2], 1)
 
     # update dilation rate, strides
     dilation_rate = (dilation_rate, 1)
     strides = (strides, 1)
-    # add dim to kernel (always same format independently of data_format)
-    # i.e. (rows, 1, input_depth, depth)
-    kernel = expand_dims(kernel, axis=1)
 
     output = _convnd(x, kernel, name='conv1d', strides=strides, filter_dilation=dilation_rate,
                      padding_mode=padding, data_format=data_format)

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -859,5 +859,46 @@ def test_sequential_mxnet_model_saving_no_compile():
         save_mxnet_model(model, prefix='test', epoch=0)
 
 
+@pytest.mark.skipif((K.backend() != 'mxnet'),
+                    reason='Supported for MXNet backend only.')
+@keras_test
+def test_sequential_get_mxnet_model_info():
+    model = Sequential()
+    model.add(Dense(2, input_shape=(3,)))
+    model.add(RepeatVector(3))
+    model.add(TimeDistributed(Dense(3)))
+    model.compile(loss=losses.MSE,
+                  optimizer=optimizers.RMSprop(lr=0.0001),
+                  metrics=[metrics.categorical_accuracy],
+                  sample_weight_mode='temporal')
+    x = np.random.random((1, 3))
+    y = np.random.random((1, 3, 3))
+    model.train_on_batch(x, y)
+
+    data_names, data_shapes = K.get_mxnet_model_info(model)
+
+    # Only one input
+    assert len(data_names) == 1
+    # Example data_names = ['/dense_8_input1']
+    assert data_names[0].startswith('/dense_')
+
+    # Example data_shape = [DataDesc[/dense_8_input1,(1, 3),float32,NCHW]]
+    assert len(data_shapes) == 1
+    assert data_shapes[0].name == data_names[0]
+    assert data_shapes[0].shape == (1, 3) # In this example, we are passing x as input with shape (1,3)
+
+
+@pytest.mark.skipif((K.backend() != 'mxnet'),
+                    reason='Supported for MXNet backend only.')
+@keras_test
+def test_sequential_get_mxnet_model_info_no_compile():
+    model = Sequential()
+    model.add(Dense(2, input_shape=(3,)))
+    model.add(RepeatVector(3))
+    model.add(TimeDistributed(Dense(3)))
+    with pytest.raises(AssertionError):
+        K.get_mxnet_model_info(model)
+
+
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
* Adding a new API in MXNet backend - `data_names, data_shapes = get_mxnet_model_info(model)` for users to be able to query MXNet backend to see what is underlying MXNet model metadata. 
* This API is typically useful for users using MXNetModelCheckpoint to save best model as native MXNet model but, through checkpoint they can't get the MXNet model details. So they will use this API for fetching those details to bind to MXNet module.

@kalyc @roywei