### PR TITLE
Support slicing axis in Keras Tensor with MXNet backend

### DIFF
--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -3945,7 +3945,9 @@ class KerasSymbol(object):
         for i in in_slice:
             if isinstance(i, int):
                 # Want to slice the complete axis
-                if i == -1:
+                if i < -1:
+                    raise NotImplementedError('MXNet Backend: Does not support slicing with < -1 indexing. Given - ', i)
+                elif i == -1:
                     begin.append(-1)
                     end.append(None)
                     slice_axis = True

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -3931,18 +3931,50 @@ class KerasSymbol(object):
         # Convert it to a tuple iterator for single dimensional bias Tensors
         if not isinstance(in_slice, (list, tuple)):
             in_slice = (in_slice,)
+
+        # MXNet sym.slice() operator does not support slicing the complete axis with '-1' indexing.
+        # See here for more details - https://github.com/awslabs/keras-apache-mxnet/issues/113
+        # This is a workaround solution, where:
+        # 1. We slice all the elements with indexing -1
+        # 2. Squeeze the axis to get the effect of slicing the complete axis.
+        # Ex: if input.shape (2,2,3) and indexing is like input[:, -1, :]
+        #     1. After step 1, result = (2,1,3)
+        #     2. After step 2, result = (2,3) which is same as Numpy and other backend behavior.
+        slice_axis = False
+        sliced_dim = [d for d in range(len(in_slice)) if in_slice[d] == -1]
         for i in in_slice:
             if isinstance(i, int):
-                begin.append(i)
-                end.append(i + 1)
+                # Want to slice the complete axis
+                if i == -1:
+                    begin.append(-1)
+                    end.append(None)
+                    slice_axis = True
+                else:
+                    begin.append(i)
+                    end.append(i + 1)
             elif isinstance(i, slice):
                 assert i.step is None or i.step == 1
                 begin.append(i.start)
                 end.append(i.stop)
             else:
                 raise AttributeError('MXNet Backend: KerasSymbol __getitem__ error.')
-        return KerasSymbol(mx.sym.slice(self.symbol, begin=tuple(begin),
-                                        end=tuple(end)), neighbors=[self])
+        sliced_res = mx.sym.slice(self.symbol, begin=tuple(begin),
+                                  end=tuple(end))
+        if slice_axis:
+            num_sliced_axis = 0
+            for dim in sliced_dim:
+                sliced_res = mx.sym.squeeze(sliced_res, axis=dim - num_sliced_axis)
+                num_sliced_axis += 1
+
+        sliced_keras_symbol = KerasSymbol(sliced_res, neighbors=[self])
+
+        # MXNet does not support Scalars. To overcome that,
+        # we have introduced a logic to identify (1, ) shaped tensor as vector or scalar.
+        # See eval() function for more details.
+        # Output of slicing is always a Vector. Without this flag, eval(a tensor with (1,) shape)
+        # will be returned as Scalar.
+        sliced_keras_symbol._is_vector = True
+        return sliced_keras_symbol
 
     @keras_mxnet_symbol
     def __abs__(self):

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -135,12 +135,6 @@ def get(identifier):
     if isinstance(identifier, dict):
         return deserialize(identifier)
     elif callable(identifier):
-        if K.backend() == 'mxnet':
-            warnings.warn('MXNet Backend: If you are using a custom loss function and use slice operator in custom '
-                          'loss function, please set the **_keras_shape** attribute of the loss tensor explicitly.\n\n'
-                          'Without this workaround, you may encounter shape mismatch errors in the broadcast '
-                          'operations.\n\nFor more details - '
-                          'https://github.com/awslabs/keras-apache-mxnet/issues/120\n\n')
         return identifier
     else:
         raise ValueError('Could not interpret '

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1852,6 +1852,16 @@ class TestBackend(object):
             with pytest.raises(TypeError):
                 K.variable('', dtype='unsupported')
 
+    @pytest.mark.skipif((K.backend() != 'mxnet'),
+                        reason='Testing only for MXNet backend')
+    def test_tensor_slicing(self):
+        np_data = np.random.randn(3, 2, 3)
+        np_res = np_data[:, -1, -1]
+
+        var = K.variable(np_data, dtype=np_data.dtype)
+        res = K.eval(var[:, -1, -1])
+        assert np.array_equal(res, np_res)
+
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
### Summary
* Support slicing the axis with '-1' indexing in tensors. Without this change we cannot slice a Keras Tensor with MXNet backend something like var[:, -1, :]
* Remove custom loss function warning, as the related MXNet slice and slice_axis issue https://github.com/awslabs/keras-apache-mxnet/issues/120 is resolved.

### Related Issues
* This PR will fix - https://github.com/awslabs/keras-apache-mxnet/issues/113
* This PR will fix - https://github.com/awslabs/keras-apache-mxnet/issues/139

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n]

@roywei @kalyc 