### PR TITLE
Add sparse sum, mean and dot operator support

### DIFF
--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -203,6 +203,8 @@ def to_dense(tensor):
         return tensor.stype('default')
     elif isinstance(tensor, KerasSymbol):
         return eval(tensor)
+    else:
+        return tensor
 
 
 def variable(value, dtype=None, name=None, constraint=None):
@@ -4174,7 +4176,7 @@ def dfs_get_bind_values(node_start):
     return bind_values
 
 
-def _keras_variable(name, shape, dtype, stype, is_vector=False, **kwargs):
+def _keras_variable(name, shape, dtype, stype='default', is_vector=False, **kwargs):
     if dtype is None:
         dtype = floatx()
     v = mx.sym.Variable(name, shape=shape, stype=stype, dtype=dtype, **kwargs)

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -1248,7 +1248,7 @@ def sum(x, axis=None, keepdims=False):
         A tensor with sum of `x`.
     """
     axis = _normalize_axis(axis, ndim(x))
-    return KerasSymbol(mx.symbol.sparse.sum(data=x.symbol, axis=axis, keepdims=keepdims))
+    return KerasSymbol(mx.sym.sum(data=x.symbol, axis=axis, keepdims=keepdims))
 
 
 @keras_mxnet_symbol
@@ -1366,9 +1366,9 @@ def mean(x, axis=None, keepdims=False):
     if dtype(x) == 'uint8':
         x = cast(x, floatx())
     if axis is not None:
-        ret = mx.symbol.sparse.mean(data=x.symbol, axis=axis, keepdims=keepdims)
+        ret = mx.sym.mean(data=x.symbol, axis=axis, keepdims=keepdims)
     else:
-        ret = mx.symbol.sparse.mean(data=x.symbol, keepdims=keepdims)
+        ret = mx.sym.mean(data=x.symbol, keepdims=keepdims)
     return KerasSymbol(ret)
 
 

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -1248,7 +1248,7 @@ def sum(x, axis=None, keepdims=False):
         A tensor with sum of `x`.
     """
     axis = _normalize_axis(axis, ndim(x))
-    return KerasSymbol(mx.sym.sum(data=x.symbol, axis=axis, keepdims=keepdims))
+    return KerasSymbol(mx.symbol.sparse.sum(data=x.symbol, axis=axis, keepdims=keepdims))
 
 
 @keras_mxnet_symbol
@@ -1366,9 +1366,9 @@ def mean(x, axis=None, keepdims=False):
     if dtype(x) == 'uint8':
         x = cast(x, floatx())
     if axis is not None:
-        ret = mx.sym.mean(data=x.symbol, axis=axis, keepdims=keepdims)
+        ret = mx.symbol.sparse.mean(data=x.symbol, axis=axis, keepdims=keepdims)
     else:
-        ret = mx.sym.mean(data=x.symbol, keepdims=keepdims)
+        ret = mx.symbol.sparse.mean(data=x.symbol, keepdims=keepdims)
     return KerasSymbol(ret)
 
 
@@ -2682,11 +2682,11 @@ def rnn(step_function, inputs, initial_states,
         inputs.reverse()
 
     # Assume learning phase is a placeholder tensor.(F = test, T = train)
-    # Some Keras layers (e.g. Dropout, BatchNormalization) behave differently at
+    # Some Keras layers (e.g. Dropout, BatchNormalization) behave differently at
     #  training time and testing time. You can tell whether a layer uses the
-    # "learning phase" (train/test) by printing layer.uses_learning_phase, a
-    # boolean: True if the layer has a different behavior in training mode and
-    # test mode, False otherwise.
+    # "learning phase" (train/test) by printing layer.uses_learning_phase, a
+    # boolean: True if the layer has a different behavior in training mode and
+    # test mode, False otherwise.
     global uses_learning_phase
     uses_learning_phase = False
 

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -591,6 +591,7 @@ def eval(x):
     else:
         return x
 
+
 def _forward_pass(x):
     bind_values = dfs_get_bind_values(x)
     executor = x.symbol.simple_bind(mx.cpu(), grad_req='null')

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -167,9 +167,12 @@ def cast_to_floatx(x):
 
 
 def is_sparse(tensor):
-    """
-    MXNet backend do not yet support sparse tensor operations.
-    """
+    if isinstance(tensor, KerasSymbol):
+        if isinstance(_forward_pass(tensor)[0], mx.ndarray.sparse.CSRNDArray) or \
+                isinstance(_forward_pass(tensor)[0], mx.ndarray.sparse.RowSparseNDArray):
+                return True
+    elif hasattr(tensor, 'tocoo'):
+        return True
     return False
 
 
@@ -194,7 +197,12 @@ def to_dense(tensor):
         False
     ```
     """
-    raise NotImplementedError('MXNet Backend: Sparse operations are not supported yet.')
+    if hasattr(tensor, 'tocoo'):
+        return tensor.toarray()
+    elif isinstance(tensor, mx.sym.Symbol):
+        return tensor.stype('default')
+    elif isinstance(tensor, KerasSymbol):
+        return eval(tensor)
 
 
 def variable(value, dtype=None, name=None, constraint=None):
@@ -239,6 +247,15 @@ def variable(value, dtype=None, name=None, constraint=None):
     if isinstance(value, KerasSymbol):
         value = eval(value)
 
+    if hasattr(value, 'tocoo'):
+        v = mx.nd.sparse.csr_matrix((value.data, value.indices, value.indptr), shape=value.shape)
+        name = _prepare_name(name, 'variable')
+        ret = _keras_variable(name, v.shape, v.dtype, 'csr', is_vector)
+        ret._keras_shape = value.shape
+        ret._uses_learning_phase = False
+        ret.bind(v)
+        return ret
+
     # MXNet backend do not support scalars
     if isinstance(value, np.ndarray) and len(value.shape) == 0:
         raise ValueError('MXNet Backend: Scalars are not supported. Provided value for variable '
@@ -247,8 +264,7 @@ def variable(value, dtype=None, name=None, constraint=None):
     dtype = _convert_string_dtype(dtype)
     name = _prepare_name(name, 'variable')
     ndarray = mx.nd.array(value, dtype=dtype)
-
-    ret = _keras_variable(name, ndarray.shape, ndarray.dtype, is_vector)
+    ret = _keras_variable(name, ndarray.shape, ndarray.dtype, 'default', is_vector)
     ret.bind(ndarray)
 
     if isinstance(value, np.ndarray):
@@ -375,9 +391,6 @@ def placeholder(shape=None, ndim=None, dtype=None, sparse=False, name=None):
         placeholder1:[tensor=False dtype=float32]
     ```
     """
-    if sparse:
-        raise NotImplementedError('MXNet backend do not yet support sparse tensor operations.')
-
     if dtype is None:
         dtype = floatx()
 
@@ -385,12 +398,20 @@ def placeholder(shape=None, ndim=None, dtype=None, sparse=False, name=None):
     if shape is None and ndim is None:
         raise ValueError('MXNet Backend: Specify either a shape or ndim value.')
     name = _prepare_name(name, 'placeholder')
+
+    if sparse:
+        sym = _keras_variable(name, shape=shape, dtype=dtype, stype='csr')
+        sym._keras_shape = tuple([d if d != 0 else None for d in shape])
+        sym._mxnet_placeholder = True
+        sym._uses_learning_phase = False
+        return sym
+
     if shape:
         shape = tuple([0 if dim is None else dim for dim in shape])
     else:
         shape = tuple([0 for _ in range(ndim)])
 
-    sym = _keras_variable(name, shape=shape, dtype=dtype)
+    sym = _keras_variable(name, shape=shape, dtype=dtype, stype='default')
     sym._keras_shape = tuple([d if d != 0 else None for d in shape])
     sym._mxnet_placeholder = True
     sym._uses_learning_phase = False
@@ -557,12 +578,7 @@ def eval(x):
                 _MODEL._sync_weights()
             ret = x.eval().asnumpy()
         else:
-            bind_values = dfs_get_bind_values(x)
-            executor = x.symbol.simple_bind(mx.cpu(), grad_req='null')
-            for v in executor.arg_dict:
-                bind_values[v].copyto(executor.arg_dict[v])
-            outputs = executor.forward(is_train=learning_phase())
-            ret = outputs[0].asnumpy()
+            ret = _forward_pass(x)[0].asnumpy()
 
         # If the Tensor shape is (1, ) and does not have attribute "_is_vector", then, it is considered to be scalar.
         # Return the value.
@@ -574,6 +590,14 @@ def eval(x):
         return x.asnumpy()
     else:
         return x
+
+def _forward_pass(x):
+    bind_values = dfs_get_bind_values(x)
+    executor = x.symbol.simple_bind(mx.cpu(), grad_req='null')
+    for v in executor.arg_dict:
+        bind_values[v].copyto(executor.arg_dict[v])
+    outputs = executor.forward(is_train=learning_phase())
+    return outputs
 
 
 def zeros(shape, dtype=None, name=None):
@@ -4149,10 +4173,10 @@ def dfs_get_bind_values(node_start):
     return bind_values
 
 
-def _keras_variable(name, shape, dtype, is_vector=False, **kwargs):
+def _keras_variable(name, shape, dtype, stype, is_vector=False, **kwargs):
     if dtype is None:
         dtype = floatx()
-    v = mx.sym.Variable(name, shape=shape, dtype=dtype, **kwargs)
+    v = mx.sym.Variable(name, shape=shape, stype=stype, dtype=dtype, **kwargs)
     ret = KerasSymbol(v, is_var=True)
 
     # MXNet does not support Scalars. Shape of a Scalar Tensor with MXNet is (1, ) instead of ().

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1711,12 +1711,14 @@ class TestBackend(object):
 
         x_sparse = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
         x_dense = x_sparse.toarray()
+        test_var = K.variable(x_sparse)
+        dense_var = K.variable(x_dense)
 
-        W = np.random.random((5, 4))
+        k_s = K.eval(K.sum(test_var, axis=0))
+        k_d = K.eval(K.sum(dense_var, axis=0))
 
-        k_s = K.eval(K.sum(K.variable(x_sparse), axis=0))
-        k_d = K.eval(K.sum(K.variable(x_dense), axis=0))
-
+        assert K.is_sparse(test_var)
+        assert K.is_sparse(dense_var) == False
         assert k_s.shape == k_d.shape
         assert_allclose(k_s, k_d, atol=1e-05)
 
@@ -1729,10 +1731,14 @@ class TestBackend(object):
 
         x_sparse = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
         x_dense = x_sparse.toarray()
+        test_var = K.variable(x_sparse)
+        dense_var = K.variable(x_dense)
 
-        k_s = K.eval(K.mean(K.variable(x_sparse), axis=0))
-        k_d = K.eval(K.mean(K.variable(x_dense), axis=0))
+        k_s = K.eval(K.mean(test_var, axis=0))
+        k_d = K.eval(K.mean(dense_var, axis=0))
 
+        assert K.is_sparse(test_var)
+        assert K.is_sparse(dense_var) == False
         assert k_s.shape == k_d.shape
         assert_allclose(k_s, k_d, atol=1e-05)
 
@@ -1745,12 +1751,60 @@ class TestBackend(object):
 
         x_sparse = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
         x_dense = x_sparse.toarray()
+        test_var = K.variable(x_sparse)
+        dense_var = K.variable(x_dense)
 
-        k_s = K.eval(K.mean(K.variable(x_sparse)))
-        k_d = K.eval(K.mean(K.variable(x_dense)))
+        k_s = K.eval(K.mean(test_var))
+        k_d = K.eval(K.mean(dense_var))
 
+        assert K.is_sparse(test_var)
+        assert K.is_sparse(dense_var) == False
         assert k_s.shape == k_d.shape
         assert_allclose(k_s, k_d, atol=1e-05)
+
+    @pytest.mark.skipif((K.backend() != 'mxnet'),
+                        reason='Testing only for MXNet backend')
+    def test_is_sparse_matrix(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse_matrix = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+
+        assert K.is_sparse(x_sparse_matrix) == True
+
+    def test_is_sparse(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse_matrix = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+        test_var = K.variable(x_sparse_matrix)
+
+        assert K.is_sparse(test_var) == True
+
+    @pytest.mark.skipif((K.backend() != 'mxnet'),
+                        reason='Testing only for MXNet backend')
+    def test_to_dense(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse_matrix = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+        test_var = K.variable(x_sparse_matrix)
+
+        assert_allclose(K.to_dense(test_var), x_sparse_matrix.toarray())
+
+    @pytest.mark.skipif((K.backend() != 'mxnet'),
+                        reason='Testing only for MXNet backend')
+    def test_to_dense_matrix(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse_matrix = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+
+        assert_allclose(K.to_dense(x_sparse_matrix), x_sparse_matrix.toarray())
 
     @pytest.mark.skipif(K.backend() == 'cntk' or K.backend() == 'mxnet', reason='Not supported.')
     def test_map(self):

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1718,7 +1718,6 @@ class TestBackend(object):
         k_d = K.eval(K.sum(dense_var, axis=0))
 
         assert K.is_sparse(test_var)
-        assert K.is_sparse(dense_var) == False
         assert k_s.shape == k_d.shape
         assert_allclose(k_s, k_d, atol=1e-05)
 
@@ -1738,7 +1737,6 @@ class TestBackend(object):
         k_d = K.eval(K.mean(dense_var, axis=0))
 
         assert K.is_sparse(test_var)
-        assert K.is_sparse(dense_var) == False
         assert k_s.shape == k_d.shape
         assert_allclose(k_s, k_d, atol=1e-05)
 
@@ -1758,7 +1756,6 @@ class TestBackend(object):
         k_d = K.eval(K.mean(dense_var))
 
         assert K.is_sparse(test_var)
-        assert K.is_sparse(dense_var) == False
         assert k_s.shape == k_d.shape
         assert_allclose(k_s, k_d, atol=1e-05)
 
@@ -1771,7 +1768,7 @@ class TestBackend(object):
 
         x_sparse_matrix = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
 
-        assert K.is_sparse(x_sparse_matrix) == True
+        assert K.is_sparse(x_sparse_matrix)
 
     def test_is_sparse(self):
         x_d = np.array([0, 7, 2, 3], dtype=np.float32)
@@ -1781,7 +1778,7 @@ class TestBackend(object):
         x_sparse_matrix = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
         test_var = K.variable(x_sparse_matrix)
 
-        assert K.is_sparse(test_var) == True
+        assert K.is_sparse(test_var)
 
     @pytest.mark.skipif((K.backend() != 'mxnet'),
                         reason='Testing only for MXNet backend')

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -1702,6 +1702,56 @@ class TestBackend(object):
             assert k_s_d.shape == k_d.shape
             assert_allclose(k_s_d, k_d, atol=1e-05)
 
+    @pytest.mark.skipif((K.backend() != 'mxnet'),
+                        reason='Testing only for MXNet backend')
+    def test_sparse_sum(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+        x_dense = x_sparse.toarray()
+
+        W = np.random.random((5, 4))
+
+        k_s = K.eval(K.sum(K.variable(x_sparse), axis=0))
+        k_d = K.eval(K.sum(K.variable(x_dense), axis=0))
+
+        assert k_s.shape == k_d.shape
+        assert_allclose(k_s, k_d, atol=1e-05)
+
+    @pytest.mark.skipif((K.backend() != 'mxnet'),
+                        reason='Testing only for MXNet backend')
+    def test_sparse_mean(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+        x_dense = x_sparse.toarray()
+
+        k_s = K.eval(K.mean(K.variable(x_sparse), axis=0))
+        k_d = K.eval(K.mean(K.variable(x_dense), axis=0))
+
+        assert k_s.shape == k_d.shape
+        assert_allclose(k_s, k_d, atol=1e-05)
+
+    @pytest.mark.skipif((K.backend() != 'mxnet'),
+                        reason='Testing only for MXNet backend')
+    def test_sparse_mean_axis_none(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+        x_dense = x_sparse.toarray()
+
+        k_s = K.eval(K.mean(K.variable(x_sparse)))
+        k_d = K.eval(K.mean(K.variable(x_dense)))
+
+        assert k_s.shape == k_d.shape
+        assert_allclose(k_s, k_d, atol=1e-05)
+
     @pytest.mark.skipif(K.backend() == 'cntk' or K.backend() == 'mxnet', reason='Not supported.')
     def test_map(self):
         x = np.random.rand(10, 3).astype(np.float32)

--- a/tests/keras/backend/mxnet_sparse_test.py
+++ b/tests/keras/backend/mxnet_sparse_test.py
@@ -1,0 +1,144 @@
+import pytest
+from numpy.testing import assert_allclose
+import numpy as np
+import warnings
+import scipy.sparse as sparse
+
+from keras import backend as K
+
+
+BACKEND = None
+
+try:
+    from keras.backend import mxnet_backend as KMX
+    BACKEND = KMX
+except ImportError:
+    KMX = None
+    warnings.warn('Could not import the MXNet backend')
+
+class TestMXNetSparse(object):
+
+    @pytest.mark.skipif((K.backend() != 'mxnet'),
+                        reason='Testing only for MXNet backend')
+    def test_is_sparse(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse_matrix = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+        test_var = K.variable(x_sparse_matrix)
+
+        assert K.is_sparse(test_var)
+
+    @pytest.mark.skipif((K.backend() != 'mxnet'),
+                        reason='Testing only for MXNet backend')
+    def test_is_sparse_matrix(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse_matrix = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+
+        assert K.is_sparse(x_sparse_matrix)
+
+    @pytest.mark.skipif((K.backend() != 'mxnet'),
+                        reason='Testing only for MXNet backend')
+    def test_to_dense(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse_matrix = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+        test_var = K.variable(x_sparse_matrix)
+
+        assert_allclose(K.to_dense(test_var), x_sparse_matrix.toarray())
+
+    @pytest.mark.skipif((K.backend() != 'mxnet'),
+                        reason='Testing only for MXNet backend')
+    def test_to_dense_matrix(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse_matrix = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+
+        assert_allclose(K.to_dense(x_sparse_matrix), x_sparse_matrix.toarray())
+
+    @pytest.mark.skipif((K.backend() != 'mxnet'),
+                        reason='Testing only for MXNet backend')
+    def test_sparse_sum(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+        x_dense = x_sparse.toarray()
+        test_var = K.variable(x_sparse)
+        dense_var = K.variable(x_dense)
+
+        k_s = K.eval(K.sum(test_var, axis=0))
+        k_d = K.eval(K.sum(dense_var, axis=0))
+
+        assert K.is_sparse(test_var)
+        assert k_s.shape == k_d.shape
+        assert_allclose(k_s, k_d, atol=1e-05)
+
+    @pytest.mark.skipif((K.backend() != 'mxnet'),
+                        reason='Testing only for MXNet backend')
+    def test_sparse_mean(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+        x_dense = x_sparse.toarray()
+        test_var = K.variable(x_sparse)
+        dense_var = K.variable(x_dense)
+
+        k_s = K.eval(K.mean(test_var, axis=0))
+        k_d = K.eval(K.mean(dense_var, axis=0))
+
+        assert K.is_sparse(test_var)
+        assert k_s.shape == k_d.shape
+        assert_allclose(k_s, k_d, atol=1e-05)
+
+    @pytest.mark.skipif((K.backend() != 'mxnet'),
+                        reason='Testing only for MXNet backend')
+    def test_sparse_mean_axis_none(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+        x_dense = x_sparse.toarray()
+        test_var = K.variable(x_sparse)
+        dense_var = K.variable(x_dense)
+
+        k_s = K.eval(K.mean(test_var))
+        k_d = K.eval(K.mean(dense_var))
+
+        assert K.is_sparse(test_var)
+        assert k_s.shape == k_d.shape
+        assert_allclose(k_s, k_d, atol=1e-05)
+
+    @pytest.mark.skipif((K.backend() != 'mxnet'),
+                        reason='Testing only for MXNet backend')
+    def test_sparse_dot(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+        x_dense = x_sparse.toarray()
+
+        W = np.random.random((5, 4))
+
+        t_W = K.variable(W)
+        k_s = K.eval(K.dot(K.variable(x_sparse), t_W))
+        k_d = K.eval(K.dot(K.variable(x_dense), t_W))
+
+        assert k_s.shape == k_d.shape
+        assert_allclose(k_s, k_d, atol=1e-05)
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/tests/keras/backend/mxnet_sparse_test.py
+++ b/tests/keras/backend/mxnet_sparse_test.py
@@ -16,6 +16,7 @@ except ImportError:
     KMX = None
     warnings.warn('Could not import the MXNet backend')
 
+
 class TestMXNetSparse(object):
 
     @pytest.mark.skipif((K.backend() != 'mxnet'),


### PR DESCRIPTION
### Summary
Add sparse support for `sum`, `mean` and `dot` operators

### Related Issues
Continuing - https://github.com/awslabs/keras-apache-mxnet/pull/159
[Missing sparse operators](https://github.com/awslabs/keras-apache-mxnet/issues/18)

### PR Overview

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n] 

