### PR TITLE
Add multi hot sparse categorical crossentropy

### DIFF
--- a/examples/multi_hot_sparse_categorical_crossentropy.py
+++ b/examples/multi_hot_sparse_categorical_crossentropy.py
@@ -1,0 +1,115 @@
+'''Trains a simple convnet on multi label classification using multi_hot_sparse_categorical_crossentropy
+
+This example demonstrate
+1) how to do multi label classification using normal categorical crossentropy
+2) when labels are sparse, how to improve performance using multi_hot_sparse_categorical_crossentropy
+'''
+
+import time
+import random
+import numpy as np
+import keras
+from keras.models import Sequential
+from keras.layers import Dense, Dropout, Flatten
+from keras.layers import Conv2D, MaxPooling2D
+from keras.preprocessing.sequence import pad_sequences
+
+"""
+Input:
+input data is random images of size (32, 32) in channels first data format
+
+Labels:
+Tradition labels are in the shape of (num_samples, num_class), for example:
+labels = [[0, 1, 1, ..., 0],
+          [1, 1, 0, ..., 0],
+          ...
+          [0, 0, 0, ..., 1]]
+where len(labels) = num_samples, len(labels[0]) = num_classes
+
+However, when num_classes are very large and labels are very sparse,
+we can represent them differently, for example:
+
+There are total 1000 classes, so there will be 10000 different labels.
+Each image can belong to at most 5 labels at the same time.
+labels = [[1, 2],
+          [0, 1],
+          ...
+          [999]]
+where labels is a list of list
+
+Special Note:
+To deal with different length of sparse labels, we pad them with negative values,
+so we can differentiate padding values with normal labels. It will become:
+padded_labels = pad_sequeences(labels, value=-1)
+padded_labels = [[-1, -1, -1, 1, 2],
+          [-1, -1, -1, 0, 1],
+          ...
+          [-1, -1, -1, -1, 999]]
+It will have shape (num_samples, 5) which still save space compare to dense labels.
+"""
+
+# input image dimensions
+img_rows, img_cols = 28, 28
+epoch = 5
+num_gpus = 4
+num_classes = 1000
+num_samples = 50000
+input_shape = (3, img_rows, img_cols)
+
+# creating random images of size (28, 28) as training data
+x_train = np.random.randint(0, 256, (num_samples, 3, img_rows, img_cols))
+
+# creating dense labels and sparse labels
+sparse_labels = []
+dense_labels = np.zeros((num_samples, num_classes))
+for i in range(0, num_samples):
+    # each data have at most 5 labels
+    for j in range(0, 5):
+        label = random.randint(0, num_classes - 1)
+        dense_labels[i][label] = 1
+        # making the number of labels for each data unequal
+        if random.randint(0, 5) == 1:
+            break
+    sparse_label_j = np.where(dense_labels[i] == 1)[0]
+    sparse_labels.append(sparse_label_j)
+
+
+# construct a simple CNN model
+model = Sequential()
+model.add(Conv2D(32, kernel_size=(3, 3),
+                 activation='relu',
+                 input_shape=input_shape))
+model.add(Conv2D(64, (3, 3), activation='relu'))
+model.add(MaxPooling2D(pool_size=(2, 2)))
+model.add(Dropout(0.25))
+model.add(Flatten())
+model.add(Dense(128, activation='relu'))
+model.add(Dropout(0.5))
+model.add(Dense(num_classes, activation='softmax'))
+
+# use normal categorical crossentropy
+model.compile(loss=keras.losses.categorical_crossentropy,
+              optimizer=keras.optimizers.Adadelta(),
+              metrics=['accuracy'])
+start = time.time()
+model.fit(x_train, dense_labels,
+          batch_size=32,
+          epochs=epoch,
+          verbose=1)
+print("categorical_crossentropy time:", time.time() - start)
+
+
+# use normal multi_hot_sparse_categorical_crossentropy
+model.compile(loss=keras.losses.multi_hot_sparse_categorical_crossentropy,
+              optimizer=keras.optimizers.Adadelta(),
+              metrics=['accuracy'])
+
+# pad sparse labels into shape length with value -1 to differentiate from normal labels
+y_train_pad = pad_sequences(sparse_labels, value=-1)
+
+start = time.time()
+model.fit(x_train, y_train_pad,
+          batch_size=32,
+          epochs=epoch,
+          verbose=1)
+print("multi_hot_categorical_crossentropy time:", time.time() - start)

--- a/examples/multi_hot_sparse_categorical_crossentropy.py
+++ b/examples/multi_hot_sparse_categorical_crossentropy.py
@@ -73,7 +73,6 @@ for i in range(0, num_samples):
     sparse_label_j = np.where(dense_labels[i] == 1)[0]
     sparse_labels.append(sparse_label_j)
 
-
 # construct a simple CNN model
 model = Sequential()
 model.add(Conv2D(32, kernel_size=(3, 3),

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -3017,6 +3017,11 @@ def multi_hot_sparse_categorical_crossentropy(target, output, from_logits=False,
     >>>y_true_np2 = np.array([[1, 2], [0, 2],[0]])
     ```
     """
+    # TODO: remove version check after mxnet 1.3.1 stable release
+    if mx.__version__ != '1.3.1':
+        raise NotImplementedError('MXNet Backend: multi_hot_sparse_categorical_crossentropy only'
+                                  'works with MXNet 1.3.1 or newer, please upgrade MXNet using:'
+                                  'pip install --upgrade mxnet --pre')
     output_dimensions = list(range(ndim(output)))
     if axis != -1 and axis not in output_dimensions:
         raise ValueError(

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -3005,6 +3005,7 @@ def multi_hot_sparse_categorical_crossentropy(target, output, from_logits=False,
 
     # Example:
     ```
+    # refer to examples/multi_hot_sparse_categorical_crossentropy.py
     # for a multi-label classification problem with 3 classes
     # target with multi labels in normal categorical crossentropy
     >>>target_dense = np.array([[0, 1, 1], [1, 0, 1], [1, 0, 0]])

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -381,6 +381,13 @@ class Model(Network):
                             metric_fn = metrics_module.sparse_categorical_accuracy
                         elif metric in ('crossentropy', 'ce'):
                             metric_fn = metrics_module.sparse_categorical_crossentropy
+                    elif self.loss_functions[i] == losses.multi_hot_sparse_categorical_crossentropy:
+                        # case: multi hot sparse categorical accuracy/crossentropy
+                        # with sparse list of integer targets
+                        if metric in ('accuracy', 'acc'):
+                            metric_fn = metrics_module.multi_hot_sparse_categorical_accuracy
+                        elif metric in ('crossentropy', 'ce'):
+                            metric_fn = metrics_module.multi_hot_sparse_categorical_crossentropy
                     else:
                         # case: categorical accuracy/crossentropy
                         if metric in ('accuracy', 'acc'):

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -779,12 +779,18 @@ class Model(Network):
                         feed_output_shapes.append(output_shape)
 
             # Standardize the outputs.
+            check_shape = True
+            if K.backend() == 'mxnet':
+                for loss_fn in self.loss_functions:
+                    if loss_fn is losses.multi_hot_sparse_categorical_crossentropy:
+                        check_shape = False
             y = standardize_input_data(
                 y,
                 feed_output_names,
                 feed_output_shapes,
                 check_batch_axis=False,  # Don't enforce the batch size.
-                exception_prefix='target')
+                exception_prefix='target',
+                check_shape=check_shape)
 
             # Generate sample-wise weight values given the `sample_weight` and
             # `class_weight` arguments.

--- a/keras/engine/training.py
+++ b/keras/engine/training.py
@@ -785,19 +785,22 @@ class Model(Network):
                     else:
                         feed_output_shapes.append(output_shape)
 
-            # Standardize the outputs.
-            check_shape = True
+            check_last_layer_shape = True
+            # multi_hot_sparse_categorical_crossentropy only available in mxnet backend
             if K.backend() == 'mxnet':
                 for loss_fn in self.loss_functions:
                     if loss_fn is losses.multi_hot_sparse_categorical_crossentropy:
-                        check_shape = False
+                        # does not check the last layer shape when multi_hot_sparse_categorical_crossentropy \
+                        # is used, since we reduce the dimension of sparse labels.
+                        check_last_layer_shape = False
+            # Standardize the outputs.
             y = standardize_input_data(
                 y,
                 feed_output_names,
                 feed_output_shapes,
                 check_batch_axis=False,  # Don't enforce the batch size.
                 exception_prefix='target',
-                check_shape=check_shape)
+                check_last_layer_shape=check_last_layer_shape)
 
             # Generate sample-wise weight values given the `sample_weight` and
             # `class_weight` arguments.

--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -33,7 +33,7 @@ def standardize_input_data(data,
                            shapes=None,
                            check_batch_axis=True,
                            exception_prefix='',
-                           check_shape=True):
+                           check_last_layer_shape=True):
     """Normalizes inputs and targets provided by users.
 
     Users may pass data as a list of arrays, dictionary of arrays,
@@ -129,14 +129,18 @@ def standardize_input_data(data,
                 if not check_batch_axis:
                     data_shape = data_shape[1:]
                     shape = shape[1:]
-                if check_shape:
-                    for dim, ref_dim in zip(data_shape, shape):
-                        if ref_dim != dim and ref_dim:
-                            raise ValueError(
-                                'Error when checking ' + exception_prefix +
-                                ': expected ' + names[i] + ' to have shape ' +
-                                str(shape) + ' but got array with shape ' +
-                                str(data_shape))
+                for dim, ref_dim in zip(data_shape, shape):
+                    if ref_dim != dim and ref_dim:
+                        # ignore shape differencew in last layer only if loss is
+                        # multi_hot_sparse_categorical_crossentropy,
+                        # last layer can only be dense or activation layer
+                        if not check_last_layer_shape and names[i].startswith(("dense", "activation")):
+                            continue
+                        raise ValueError(
+                            'Error when checking ' + exception_prefix +
+                            ': expected ' + names[i] + ' to have shape ' +
+                            str(shape) + ' but got array with shape ' +
+                            str(data_shape))
     return data
 
 

--- a/keras/engine/training_utils.py
+++ b/keras/engine/training_utils.py
@@ -32,7 +32,8 @@ def standardize_input_data(data,
                            names,
                            shapes=None,
                            check_batch_axis=True,
-                           exception_prefix=''):
+                           exception_prefix='',
+                           check_shape=True):
     """Normalizes inputs and targets provided by users.
 
     Users may pass data as a list of arrays, dictionary of arrays,
@@ -128,13 +129,14 @@ def standardize_input_data(data,
                 if not check_batch_axis:
                     data_shape = data_shape[1:]
                     shape = shape[1:]
-                for dim, ref_dim in zip(data_shape, shape):
-                    if ref_dim != dim and ref_dim:
-                        raise ValueError(
-                            'Error when checking ' + exception_prefix +
-                            ': expected ' + names[i] + ' to have shape ' +
-                            str(shape) + ' but got array with shape ' +
-                            str(data_shape))
+                if check_shape:
+                    for dim, ref_dim in zip(data_shape, shape):
+                        if ref_dim != dim and ref_dim:
+                            raise ValueError(
+                                'Error when checking ' + exception_prefix +
+                                ': expected ' + names[i] + ' to have shape ' +
+                                str(shape) + ' but got array with shape ' +
+                                str(data_shape))
     return data
 
 

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -73,8 +73,13 @@ def categorical_crossentropy(y_true, y_pred):
 def sparse_categorical_crossentropy(y_true, y_pred):
     return K.sparse_categorical_crossentropy(y_true, y_pred)
 
+
 def multi_hot_sparse_categorical_crossentropy(y_true, y_pred):
+    if K.backend() != 'mxnet':
+        raise NotImplementedError('multi_hot_sparse_categorical_crossentropy '
+                                  'is only available in MXNet backend')
     return K.multi_hot_sparse_categorical_crossentropy(y_true, y_pred)
+
 
 def binary_crossentropy(y_true, y_pred):
     return K.mean(K.binary_crossentropy(y_true, y_pred), axis=-1)

--- a/keras/losses.py
+++ b/keras/losses.py
@@ -73,6 +73,8 @@ def categorical_crossentropy(y_true, y_pred):
 def sparse_categorical_crossentropy(y_true, y_pred):
     return K.sparse_categorical_crossentropy(y_true, y_pred)
 
+def multi_hot_sparse_categorical_crossentropy(y_true, y_pred):
+    return K.multi_hot_sparse_categorical_crossentropy(y_true, y_pred)
 
 def binary_crossentropy(y_true, y_pred):
     return K.mean(K.binary_crossentropy(y_true, y_pred), axis=-1)

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -15,6 +15,7 @@ from .losses import logcosh
 from .losses import squared_hinge
 from .losses import categorical_crossentropy
 from .losses import sparse_categorical_crossentropy
+from .losses import multi_hot_sparse_categorical_crossentropy
 from .losses import binary_crossentropy
 from .losses import kullback_leibler_divergence
 from .losses import poisson
@@ -35,6 +36,12 @@ def categorical_accuracy(y_true, y_pred):
 
 def sparse_categorical_accuracy(y_true, y_pred):
     return K.cast(K.equal(K.max(y_true, axis=-1),
+                          K.cast(K.argmax(y_pred, axis=-1), K.floatx())),
+                  K.floatx())
+
+
+def multi_hot_sparse_categorical_accuracy(y_true, y_pred):
+    return K.cast(K.equal(K.max(y_true, axis=-1) - 1,
                           K.cast(K.argmax(y_pred, axis=-1), K.floatx())),
                   K.floatx())
 

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -41,7 +41,7 @@ def sparse_categorical_accuracy(y_true, y_pred):
 
 
 def multi_hot_sparse_categorical_accuracy(y_true, y_pred):
-    return K.cast(K.equal(K.max(y_true, axis=-1) - 1,
+    return K.cast(K.equal(K.max(y_true, axis=-1),
                           K.cast(K.argmax(y_pred, axis=-1), K.floatx())),
                   K.floatx())
 

--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -117,3 +117,13 @@ def to_channels_first(data):
     else:
         data = to_channels_first_helper(data)
     return data
+
+
+def pad_multi_hot_labels(labels):
+    # increment labels so it can be padded with 0s and won't affect class label
+    # with 3 classes labels 0, 1 ,2 will become 1, 2, 3
+    for label in labels:
+        for j in range(0, len(label)):
+            label[j] += 1
+    from keras.preprocessing.sequence import  pad_sequences
+    return pad_sequences(labels, value=0)

--- a/keras/utils/np_utils.py
+++ b/keras/utils/np_utils.py
@@ -117,13 +117,3 @@ def to_channels_first(data):
     else:
         data = to_channels_first_helper(data)
     return data
-
-
-def pad_multi_hot_labels(labels):
-    # increment labels so it can be padded with 0s and won't affect class label
-    # with 3 classes labels 0, 1 ,2 will become 1, 2, 3
-    for label in labels:
-        for j in range(0, len(label)):
-            label[j] += 1
-    from keras.preprocessing.sequence import  pad_sequences
-    return pad_sequences(labels, value=0)

--- a/tests/keras/losses_test.py
+++ b/tests/keras/losses_test.py
@@ -109,6 +109,26 @@ def test_sparse_categorical_crossentropy_4d():
     assert np.isclose(expected_loss, np.mean(loss))
 
 
+def test_multi_hot_sparse_categorical_crossentropy:
+    y_true_np = np.array([[0, 1, 1], [1, 0, 1], [1, 0, 0]])
+    y_pred_np = np.array([[0.1, 0.4, 0.5],
+                          [0.4, 0.2, 0.4],
+                          [0.7, 0.2, 0.1]])
+    y_true_np2 = np.array([[1, 2], [0, 2], [0]])
+    loss = K.eval(losses.categorical_crossentropy(K.variable(y_true_np), K.variable(y_pred_np)))
+
+    # multi hot labels
+    # increment labels
+    for i in y_true_np2:
+        for j in range(0, len(i)):
+            i[j] += 1
+    # pad labels to have the same size
+    y_true_np2 = keras.preprocessing.sequence.pad_sequences(y_true_np2, value=0)
+    y_pred2 = K.variable(y_pred_np)
+    y_true2 = K.variable(y_true_np2)
+    loss2 = K.eval(losses.multi_hot_sparse_categorical_crossentropy(y_true2, y_pred2))
+    assert np.allclose(loss, loss2)
+
 class MSE_MAE_loss:
     """Loss function with internal state, for testing serialization code."""
     def __init__(self, mse_fraction):

--- a/tests/keras/losses_test.py
+++ b/tests/keras/losses_test.py
@@ -109,7 +109,7 @@ def test_sparse_categorical_crossentropy_4d():
     assert np.isclose(expected_loss, np.mean(loss))
 
 
-def test_multi_hot_sparse_categorical_crossentropy:
+def test_multi_hot_sparse_categorical_crossentropy():
     y_true_np = np.array([[0, 1, 1], [1, 0, 1], [1, 0, 0]])
     y_pred_np = np.array([[0.1, 0.4, 0.5],
                           [0.4, 0.2, 0.4],
@@ -117,17 +117,13 @@ def test_multi_hot_sparse_categorical_crossentropy:
     y_true_np2 = np.array([[1, 2], [0, 2], [0]])
     loss = K.eval(losses.categorical_crossentropy(K.variable(y_true_np), K.variable(y_pred_np)))
 
-    # multi hot labels
-    # increment labels
-    for i in y_true_np2:
-        for j in range(0, len(i)):
-            i[j] += 1
-    # pad labels to have the same size
-    y_true_np2 = keras.preprocessing.sequence.pad_sequences(y_true_np2, value=0)
+    # pad labels to have the same size, use -1 to differentiate from normal class labels
+    y_true_np2 = keras.preprocessing.sequence.pad_sequences(y_true_np2, value=-1)
     y_pred2 = K.variable(y_pred_np)
     y_true2 = K.variable(y_true_np2)
     loss2 = K.eval(losses.multi_hot_sparse_categorical_crossentropy(y_true2, y_pred2))
     assert np.allclose(loss, loss2)
+
 
 class MSE_MAE_loss:
     """Loss function with internal state, for testing serialization code."""

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -39,6 +39,7 @@ all_metrics_mxnet = [
 all_sparse_metrics = [
     metrics.sparse_categorical_accuracy,
     metrics.sparse_categorical_crossentropy,
+    metrics.multi_hot_sparse_categorical_accuracy
 ]
 
 


### PR DESCRIPTION
### Summary
This PR adds a new feature to calculate categorical cross-entropy on multi hot sparse labels
Inputs are softmax predictions and true labels.
It should return same loss as categorical cross-entropy.

Example:
```
Input:
input data is random images of size (32, 32) in channels first data format
 Labels:
Tradition labels are in the shape of (num_samples, num_class), for example:
labels = [[0, 1, 1, ..., 0],
          [1, 1, 0, ..., 0],
          ...
          [0, 0, 0, ..., 1]]
where len(labels) = num_samples, len(labels[0]) = num_classes
 However, when num_classes are very large and labels are very sparse,
we can represent them differently, for example:
 There are total 1000 classes, so there will be 10000 different labels.
Each image can belong to at most 5 labels at the same time.
labels = [[1, 2],
          [0, 1],
          ...
          [999]]
where labels is a list of list
 Special Note:
To deal with different length of sparse labels, we pad them with negative values,
so we can differentiate padding values with normal labels. It will become:
padded_labels = pad_sequeences(labels, value=-1)
padded_labels = [[-1, -1, -1, 1, 2],
          [-1, -1, -1, 0, 1],
          ...
          [-1, -1, -1, -1, 999]]
It will have shape (num_samples, 5) which still save space compare to dense labels.
```
### Changes

- Add implementation for loss and metrics
- Add examples at examples/multi_hot_sparse_categorical_crossentropy.py
- Add unit tests for loss and metric
- Performance:
X3 faster for calculating 3000 classes multi labeled sparse labels. (5 labels at most for each data)
```
('categorical crossentropy loss time per epoch:', 0.7335219383239746)
('multi hot sparse categorical crossentropy loss time per epoch:', 0.23781204223632812)
```

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n]
