### PR TITLE
fix sparse acc

### DIFF
--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -34,7 +34,7 @@ def categorical_accuracy(y_true, y_pred):
 
 
 def sparse_categorical_accuracy(y_true, y_pred):
-    return K.cast(K.equal(K.max(y_true, axis=-1),
+    return K.cast(K.equal(y_true,
                           K.cast(K.argmax(y_pred, axis=-1), K.floatx())),
                   K.floatx())
 

--- a/keras/metrics.py
+++ b/keras/metrics.py
@@ -34,7 +34,7 @@ def categorical_accuracy(y_true, y_pred):
 
 
 def sparse_categorical_accuracy(y_true, y_pred):
-    return K.cast(K.equal(y_true,
+    return K.cast(K.equal(K.flatten(y_true),
                           K.cast(K.argmax(y_pred, axis=-1), K.floatx())),
                   K.floatx())
 

--- a/tests/keras/legacy/interface_test.py
+++ b/tests/keras/legacy/interface_test.py
@@ -769,9 +769,6 @@ def test_cropping3d_legacy_interface():
     assert json.dumps(old_layer.get_config()) == json.dumps(new_layer.get_config())
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support '
-                           'sparse_categorical_crossentropy yet.')
 @keras_test
 def test_generator_methods_interface():
     def train_generator():

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -64,6 +64,17 @@ def test_sparse_metrics():
         assert K.eval(metric(y_a, y_b)).shape == (6,)
 
 
+@keras_test
+def test_sparse_categorical_accuracy_correctness():
+    y_a = K.variable(np.random.randint(0, 7, (6,)), dtype=K.floatx())
+    y_b = K.variable(np.random.random((6, 7)), dtype=K.floatx())
+    # use one_hot embedding to convert sparse labels to equivalent dense labels
+    y_a_dense_labels = K.cast(K.one_hot(K.cast(y_a, dtype='int32'), num_classes=7), dtype=K.floatx())
+    sparse_categorical_acc = metrics.sparse_categorical_accuracy(y_a, y_b)
+    categorical_acc = metrics.categorical_accuracy(y_a_dense_labels, y_b)
+    assert np.allclose(K.eval(sparse_categorical_acc), K.eval(categorical_acc))
+
+
 def test_serialize():
     '''This is a mock 'round trip' of serialize and deserialize.
     '''


### PR DESCRIPTION
### Summary
Fix https://github.com/awslabs/keras-apache-mxnet/issues/165

### Related Issues
https://github.com/awslabs/keras-apache-mxnet/issues/165
### PR Overview

1. sparse categorical acc should have the same result as categorical acc.

For example, with 3 classes, given `sparse_true_label = [0, 1, 1]`, it's equivalent in categorical labels is `dense_true_label = [[1, 0, 0], [0, 1, 0], [0, 1, 0]]`. With the same predictions 
```
pred = [[0.7, 0.2, 0.1], 
[0.1, 0.1, 0.8], 
[0.2, 0.6, 0.2]]
```
They should produce the same acc which is `[1, 0 ,1]`

2. Not sure why `max` is used, but it should directly compare with `y_true`
3. Added unit test to test correctness

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n]
