### PR TITLE
Add sparse concat operator support

### DIFF
--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -17,6 +17,8 @@ _MODEL = None
 _REENTRY = False
 NAME_SCOPE_STACK = []
 
+py_all = all
+
 
 class name_scope(object):
     def __init__(self, name):
@@ -2030,6 +2032,10 @@ def concatenate(tensors, axis=-1):
 
     # Returns
         A tensor.
+
+    Note:
+    - MXNet supports sparse concat only for dim=0
+    - https://mxnet.apache.org/api/python/symbol/sparse.html#mxnet.symbol.sparse.concat
     """
     if axis < 0:
         rank = ndim(tensors[0])
@@ -2038,8 +2044,12 @@ def concatenate(tensors, axis=-1):
         else:
             axis = 0
 
-    tensors = [t.symbol for t in tensors]
-    return KerasSymbol(mx.sym.concat(*tensors, dim=axis))
+    symbols = [t.symbol for t in tensors]
+
+    if py_all([is_sparse(t) for t in tensors]):
+        return KerasSymbol(mx.sym.sparse.concat(*symbols, dim=0))
+
+    return KerasSymbol(mx.sym.concat(*symbols, dim=axis))
 
 
 @keras_mxnet_symbol

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -2046,8 +2046,8 @@ def concatenate(tensors, axis=-1):
 
     symbols = [t.symbol for t in tensors]
 
-    if py_all([is_sparse(t) for t in tensors]):
-        return KerasSymbol(mx.sym.sparse.concat(*symbols, dim=0))
+    if axis == 0 and py_all([is_sparse(t) for t in tensors]):
+        return KerasSymbol(mx.sym.sparse.concat(*symbols, dim=axis))
 
     return KerasSymbol(mx.sym.concat(*symbols, dim=axis))
 

--- a/tests/keras/backend/mxnet_sparse_test.py
+++ b/tests/keras/backend/mxnet_sparse_test.py
@@ -104,6 +104,35 @@ class TestMXNetSparse(object):
         assert k_s.shape == k_d.shape
         assert_allclose(k_s, k_d, atol=1e-05)
 
+    def test_sparse_concat(self):
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse_1 = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+
+        x_d = np.array([0, 7, 2, 3], dtype=np.float32)
+        x_r = np.array([0, 2, 2, 3], dtype=np.int64)
+        x_c = np.array([4, 3, 2, 3], dtype=np.int64)
+
+        x_sparse_2 = sparse.csr_matrix((x_d, (x_r, x_c)), shape=(4, 5))
+
+        assert K.is_sparse(K.variable(x_sparse_1))
+        assert K.is_sparse(K.variable(x_sparse_2))
+        x_dense_1 = x_sparse_1.toarray()
+        x_dense_2 = x_sparse_2.toarray()
+
+        k_s = K.concatenate(tensors=[K.variable(x_sparse_1), K.variable(x_sparse_2)])
+        assert K.is_sparse(k_s)
+
+        k_s_d = K.eval(k_s)
+
+        # mx.sym.sparse.concat only supported for axis=0
+        k_d = K.eval(K.concatenate(tensors=[K.variable(x_dense_1), K.variable(x_dense_2)], axis=0))
+
+        assert k_s_d.shape == k_d.shape
+        assert_allclose(k_s_d, k_d, atol=1e-05)
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/keras/backend/mxnet_sparse_test.py
+++ b/tests/keras/backend/mxnet_sparse_test.py
@@ -113,7 +113,7 @@ class TestMXNetSparse(object):
         x_dense_1 = x_sparse_1.toarray()
         x_dense_2 = x_sparse_2.toarray()
 
-        k_s = K.concatenate(tensors=[K.variable(x_sparse_1), K.variable(x_sparse_2)])
+        k_s = K.concatenate(tensors=[K.variable(x_sparse_1), K.variable(x_sparse_2)], axis=0)
         assert K.is_sparse(k_s)
 
         k_s_d = K.eval(k_s)
@@ -151,13 +151,13 @@ class TestMXNetSparse(object):
         x_dense_1 = x_sparse_1.toarray()
         x_dense_2 = x_sparse_2.toarray()
 
-        k_s = K.concatenate(tensors=[K.variable(x_sparse_1), K.variable(x_dense_2)], axis=0)
+        k_s = K.concatenate(tensors=[K.variable(x_sparse_1), K.variable(x_dense_2)])
         assert not (K.is_sparse(k_s))
 
         k_s_d = K.eval(k_s)
 
         # mx.sym.sparse.concat only supported for axis=0
-        k_d = K.eval(K.concatenate(tensors=[K.variable(x_dense_1), K.variable(x_dense_2)], axis=0))
+        k_d = K.eval(K.concatenate(tensors=[K.variable(x_dense_1), K.variable(x_dense_2)]))
 
         assert k_s_d.shape == k_d.shape
         assert_allclose(k_s_d, k_d, atol=1e-05)


### PR DESCRIPTION
### Summary
Add sparse support for `concat` operator

### Related Issues
[Missing sparse operators](https://github.com/awslabs/keras-apache-mxnet/issues/18)

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n]
