### PR TITLE
Full RNN support with control flow ops

### DIFF
--- a/docs/mxnet_backend/using_rnn_with_mxnet_backend.md
+++ b/docs/mxnet_backend/using_rnn_with_mxnet_backend.md
@@ -3,24 +3,20 @@
 ## Table of Contents
 
 1. [Overview](#overview)
-2. [Variable length inputs are not supported](#variable-length-inputs-are-not-supported)
-3. [Unroll=False is not supported](#unrollfalse-is-not-supported)
+2. [Variable length inputs are not supported for unrolling](#variable-length-inputs-are-not-supported-for-unrolling)
+3. [Using Unrolling in RNN](#using-unrolling-in-rnn)
 4. [Slower CPU training performance](#slower-cpu-training-performance)
 
 ## Overview
 
 In this document, we describe the limitations of using RNNs with MXNet backend and available workarounds for the same.
 
-## Variable length inputs are not supported
+## Variable length inputs are not supported for unrolling
 
-MXNet backend does not support variable length inputs in the recurrent layers. To overcome this limitation, you can 
+MXNet backend does not support variable length inputs when you unrolling RNN cells in the recurrent layers. To overcome this limitation, you can
 pad the input sequences to prepare fixed length inputs. The MXNet backend requires both the `input_shape` and 
 `unroll=True` parameters while adding the SimpleRNN/LSTM/GRU layer.
 
-```
-NOTE:
-    MXNet does not support symbolic control flow operators. However, this is a work in progress feature. This feature will be supported in upcoming releases.
-```
 
 ### Transform variable length to fixed length inputs
 
@@ -57,9 +53,13 @@ NOTE:
     arbitrary large maxlen. It is always optimal to choose maxlen for padding to be equal to the max length of the 
     input sequences.
 ```
-## Unroll=False is not supported
+## Using unrolling in RNN
 
-As described above, MXNet backend does not support variable length input and hence `unroll=False` is not supported in RNN layers. You are expected to provide `input_shape` and set `unroll=True`.
+In Keras RNN layers, by default unroll is set to False, and it requires control flow opreators(e.g. foreach, while_loop).
+We recently added support for this feature so by default RNN layers are not unrolled, same as other backends.
+
+Unrolling RNN Cells will have better performance but comsumes more memory. It's only suitable for short sequeence. For more details, refer to
+[Keras RNN API](https://keras.io/layers/recurrent/)
 
 ## Slower CPU training performance
 

--- a/docs/mxnet_backend/using_rnn_with_mxnet_backend.md
+++ b/docs/mxnet_backend/using_rnn_with_mxnet_backend.md
@@ -55,10 +55,10 @@ NOTE:
 ```
 ## Using unrolling in RNN
 
-In Keras RNN layers, by default unroll is set to False, and it requires control flow opreators(e.g. foreach, while_loop).
+In Keras RNN layers, by default unroll is set to False, and it requires control flow operators(e.g. foreach, while_loop).
 We recently added support for this feature so by default RNN layers are not unrolled, same as other backends.
 
-Unrolling RNN Cells will have better performance but comsumes more memory. It's only suitable for short sequeence. For more details, refer to
+Unrolling RNN Cells will have better performance but consumes more memory. It's only suitable for short sequences. For more details, refer to
 [Keras RNN API](https://keras.io/layers/recurrent/)
 
 ## Slower CPU training performance

--- a/examples/imdb_lstm.py
+++ b/examples/imdb_lstm.py
@@ -39,14 +39,8 @@ print('x_test shape:', x_test.shape)
 print('Build model...')
 model = Sequential()
 
-# MXNet backend does not support dropout in LSTM and cannot automatically infer shape
-if K.backend() == 'mxnet':
-    # specifying input_length and removed dropout params
-    model.add(Embedding(max_features, 128, input_length=maxlen))
-    model.add(LSTM(128, unroll=True))
-else:
-    model.add(Embedding(max_features, 128))
-    model.add(LSTM(128, dropout=0.2, recurrent_dropout=0.2))
+model.add(Embedding(max_features, 128))
+model.add(LSTM(128, dropout=0.2, recurrent_dropout=0.2))
 model.add(Dense(1, activation='sigmoid'))
 
 # try using different optimizers and different optimizer configs

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -2741,9 +2741,9 @@ def rnn(step_function, inputs, initial_states,
         outputs = mx.sym.concat(*outputs, dim=1)
     else:
         # TODO: remove version check after mxnet 1.3.1 release
-        if mx.__version__ >= '1.3.1':
-            raise NotImplementedError('unroll=False in RNN only works with MXNet 1.3.1 or newer ,'
-                                      ' please upgrade to latest master using: pip install --ugprade mxnet --pre')
+        if mx.__version__ < '1.3.1':
+            raise NotImplementedError('unroll=False in RNN only works with MXNet 1.3.1 or newer, '
+                                      'please upgrade to latest master using: pip install --ugprade mxnet --pre')
 
         # defining step functions for each RNN cells, implementation taken from call functions
         # from each RNN cell class in keras.layers.recurrent
@@ -3376,10 +3376,10 @@ def multi_hot_sparse_categorical_crossentropy(target, output, from_logits=False,
     ```
     """
     # TODO: remove version check after mxnet 1.3.1 stable release
-    if mx.__version__ >= '1.3.1':
+    if mx.__version__ < '1.3.1':
         raise NotImplementedError('MXNet Backend: multi_hot_sparse_categorical_crossentropy only'
                                   'works with MXNet 1.3.1 or newer, please upgrade MXNet using:'
-                                  'p    ip install --upgrade mxnet --pre')
+                                  'pip install --upgrade mxnet --pre')
     output_dimensions = list(range(ndim(output)))
     if axis != -1 and axis not in output_dimensions:
         raise ValueError(
@@ -5361,12 +5361,14 @@ def get_model():
                     try:
                         self._args[name][:] = args[name]
                     except:
+                        # when name is not in self._args (key not found)
                         self._args[name] = []
                         self._args[name][:] = args[name]
                 for name in self._aux_names:
                     try:
                         self._auxs[name][:] = auxs[name]
                     except:
+                        # when name is not in self._auxs (key not found)
                         self._auxs[name] = []
                         self._auxs[name][:] = auxs[name]
                 self._weights_dirty = False

--- a/keras/layers/recurrent.py
+++ b/keras/layers/recurrent.py
@@ -606,15 +606,26 @@ class RNN(Layer):
         else:
             def step(inputs, states):
                 return self.cell.call(inputs, states, **kwargs)
-
-        last_output, outputs, states = K.rnn(step,
-                                             inputs,
-                                             initial_state,
-                                             constants=constants,
-                                             go_backwards=self.go_backwards,
-                                             mask=mask,
-                                             unroll=self.unroll,
-                                             input_length=timesteps)
+        if K.backend() == 'mxnet':
+            last_output, outputs, states = K.rnn(step,
+                                                 inputs,
+                                                 initial_state,
+                                                 constants=constants,
+                                                 go_backwards=self.go_backwards,
+                                                 mask=mask,
+                                                 unroll=self.unroll,
+                                                 input_length=timesteps,
+                                                 cell=self.cell,
+                                                 training=training)
+        else:
+            last_output, outputs, states = K.rnn(step,
+                                                 inputs,
+                                                 initial_state,
+                                                 constants=constants,
+                                                 go_backwards=self.go_backwards,
+                                                 mask=mask,
+                                                 unroll=self.unroll,
+                                                 input_length=timesteps)
         if self.stateful:
             updates = []
             for i in range(len(states)):

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -42,9 +42,6 @@ def rnn_cell_test(f):
     ])(f)
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @rnn_test
 def test_return_sequences(layer_class):
     layer_test(layer_class,
@@ -53,9 +50,6 @@ def test_return_sequences(layer_class):
                input_shape=(num_samples, timesteps, embedding_dim))
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @rnn_test
 def test_dynamic_behavior(layer_class):
     layer = layer_class(units, input_shape=(None, embedding_dim))
@@ -67,9 +61,6 @@ def test_dynamic_behavior(layer_class):
     model.train_on_batch(x, y)
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @rnn_test
 def test_stateful_invalid_use(layer_class):
     layer = layer_class(units,
@@ -167,9 +158,6 @@ def test_statefulness(layer_class):
     assert(out4.max() != out5.max())
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @rnn_test
 def test_masking_correctness(layer_class):
     # Check masking: output with left padding and right padding
@@ -196,9 +184,6 @@ def test_masking_correctness(layer_class):
     assert_allclose(out7, out6, atol=1e-5)
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @rnn_test
 def test_implementation_mode(layer_class):
     for mode in [1, 2]:
@@ -222,9 +207,6 @@ def test_implementation_mode(layer_class):
                    input_shape=(num_samples, timesteps, embedding_dim))
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @rnn_test
 def test_regularizer(layer_class):
     layer = layer_class(units, return_sequences=False, weights=None,
@@ -263,9 +245,6 @@ def test_trainability(layer_class):
     assert len(layer.non_trainable_weights) == 0
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @keras_test
 def test_masking_layer():
     ''' This test based on a previously failing issue here:
@@ -297,9 +276,6 @@ def test_from_config(layer_class):
         assert l1.get_config() == l2.get_config()
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @rnn_test
 def test_specify_initial_state_keras_tensor(layer_class):
     num_states = 2 if layer_class is recurrent.LSTM else 1
@@ -324,9 +300,6 @@ def test_specify_initial_state_keras_tensor(layer_class):
     model.fit([inputs] + initial_state, targets)
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @rnn_test
 def test_specify_initial_state_non_keras_tensor(layer_class):
     num_states = 2 if layer_class is recurrent.LSTM else 1
@@ -372,9 +345,6 @@ def test_reset_states_with_values(layer_class):
         layer.reset_states([1] * (len(layer.states) + 1))
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @rnn_test
 def test_initial_states_as_other_inputs(layer_class):
     num_states = 2 if layer_class is recurrent.LSTM else 1
@@ -398,9 +368,6 @@ def test_initial_states_as_other_inputs(layer_class):
     model.train_on_batch([main_inputs] + initial_state, targets)
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @rnn_test
 def test_specify_state_with_masking(layer_class):
     ''' This test based on a previously failing issue here:
@@ -423,9 +390,6 @@ def test_specify_state_with_masking(layer_class):
     model.fit([inputs] + initial_state, targets)
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @rnn_test
 def test_return_state(layer_class):
     num_states = 2 if layer_class is recurrent.LSTM else 1
@@ -442,9 +406,6 @@ def test_return_state(layer_class):
     np.testing.assert_allclose(K.eval(layer.states[0]), state, atol=1e-4)
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @rnn_test
 def test_state_reuse(layer_class):
     inputs = Input(batch_shape=(num_samples, timesteps, embedding_dim))
@@ -461,9 +422,6 @@ def test_state_reuse(layer_class):
 @rnn_test
 @pytest.mark.skipif((K.backend() in ['theano']),
                     reason='Not supported.')
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 def test_state_reuse_with_dropout(layer_class):
     input1 = Input(batch_shape=(num_samples, timesteps, embedding_dim))
     layer = layer_class(units, return_state=True, return_sequences=True, dropout=0.2)
@@ -478,9 +436,6 @@ def test_state_reuse_with_dropout(layer_class):
     outputs = model.predict(inputs)
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @keras_test
 def test_minimal_rnn_cell_non_layer():
 
@@ -517,9 +472,6 @@ def test_minimal_rnn_cell_non_layer():
     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @keras_test
 def test_minimal_rnn_cell_non_layer_multiple_states():
 
@@ -595,11 +547,7 @@ def test_minimal_rnn_cell_layer():
             return dict(list(base_config.items()) + list(config.items()))
 
     # Test basic case.
-    if K.backend() == 'mxnet':
-        # MXNet backend requires input shape
-        x = keras.Input((6, 5))
-    else:
-        x = keras.Input((None, 5))
+    x = keras.Input((None, 5))
     cell = MinimalRNNCell(32)
     layer = recurrent.RNN(cell)
     y = layer(x)
@@ -644,14 +592,12 @@ def test_minimal_rnn_cell_layer():
     assert_allclose(y_np, y_np_2, atol=1e-4)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support custom RNN layers yet')
 @rnn_cell_test
 def test_builtin_rnn_cell_layer(cell_class):
     # Test basic case.
-    if K.backend() == 'mxnet':
-        # MXNet backend requires input shape
-        x = keras.Input((6, 5))
-    else:
-        x = keras.Input((None, 5))
+    x = keras.Input((None, 5))
     cell = cell_class(32)
     layer = recurrent.RNN(cell)
     y = layer(x)
@@ -698,8 +644,7 @@ def test_builtin_rnn_cell_layer(cell_class):
 @pytest.mark.skipif((K.backend() in ['cntk', 'theano']),
                     reason='Not supported.')
 @pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
+                    reason='MXNet backend does not support custom RNN layers yet')
 def test_stacked_rnn_dropout():
     cells = [recurrent.LSTMCell(3, dropout=0.1, recurrent_dropout=0.1),
              recurrent.LSTMCell(3, dropout=0.1, recurrent_dropout=0.1)]
@@ -751,9 +696,6 @@ def test_stacked_rnn_compute_output_shape():
     assert output_shape == expected_output_shape
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @rnn_test
 def test_batch_size_equal_one(layer_class):
     inputs = Input(batch_shape=(1, timesteps, embedding_dim))
@@ -767,8 +709,7 @@ def test_batch_size_equal_one(layer_class):
 
 
 @pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
+                    reason='MXNet backend does not support custom RNN layers yet')
 @keras_test
 def test_rnn_cell_with_constants_layer():
 
@@ -879,8 +820,7 @@ def test_rnn_cell_with_constants_layer():
 
 
 @pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
+                    reason='MXNet backend does not support custom RNN layers yet')
 @keras_test
 def test_rnn_cell_with_constants_layer_passing_initial_state():
 

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -560,9 +560,6 @@ def test_minimal_rnn_cell_non_layer_multiple_states():
     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @keras_test
 def test_minimal_rnn_cell_layer():
 
@@ -598,7 +595,11 @@ def test_minimal_rnn_cell_layer():
             return dict(list(base_config.items()) + list(config.items()))
 
     # Test basic case.
-    x = keras.Input((None, 5))
+    if K.backend() == 'mxnet':
+        # MXNet backend requires input shape
+        x = keras.Input((6, 5))
+    else:
+        x = keras.Input((None, 5))
     cell = MinimalRNNCell(32)
     layer = recurrent.RNN(cell)
     y = layer(x)
@@ -643,13 +644,14 @@ def test_minimal_rnn_cell_layer():
     assert_allclose(y_np, y_np_2, atol=1e-4)
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support unroll=False in '
-                           'RNN yet.')
 @rnn_cell_test
 def test_builtin_rnn_cell_layer(cell_class):
     # Test basic case.
-    x = keras.Input((None, 5))
+    if K.backend() == 'mxnet':
+        # MXNet backend requires input shape
+        x = keras.Input((6, 5))
+    else:
+        x = keras.Input((None, 5))
     cell = cell_class(32)
     layer = recurrent.RNN(cell)
     y = layer(x)

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -623,7 +623,7 @@ def test_saving_recurrent_layer_with_init_state():
     input_initial_state = Input(shape=(vector_size,))
     input_x = Input(shape=(input_length, vector_size))
 
-    lstm = LSTM(vector_size, return_sequences=True)(
+    lstm = LSTM(vector_size, unroll=True, return_sequences=True)(
         input_x, initial_state=[input_initial_state, input_initial_state])
 
     model = Model(inputs=[input_x, input_initial_state], outputs=[lstm])

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -832,7 +832,7 @@ def test_sequential_lstm_mxnet_model_saving():
 
     model = Sequential()
     model.add(Embedding(max_features, 128, input_length=maxlen))
-    model.add(LSTM(128, unroll=True))
+    model.add(LSTM(128))
 
     model.compile(loss='binary_crossentropy',
                   optimizer='adam',


### PR DESCRIPTION
### Summary

- Add control flow ops in RNN so we can set unroll=False as default
- resolved drop out issue: https://github.com/awslabs/keras-apache-mxnet/issues/60
- enabled 18 rnn unit tests

### Related Issues
https://github.com/awslabs/keras-apache-mxnet/wiki/Using-RNN-with-MXNet-backend
https://github.com/awslabs/keras-apache-mxnet/issues/60

### PR Overview

- [x] This PR requires new unit tests [y/n] (make sure tests are included)
- [x] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [x] This PR changes the current API [y/n]
