### PR TITLE
Fix sparse benchmark

### DIFF
--- a/benchmark/sparse/linear_regression/keras_sparse_model.py
+++ b/benchmark/sparse/linear_regression/keras_sparse_model.py
@@ -8,30 +8,25 @@ from keras import Model
 from keras.layers import Dense, Input
 from keras.optimizers import SGD
 from keras import backend as K
-import mxnet as mx
 
 
 def run_benchmark(train_data, train_label, eval_data, eval_label, batch_size, epochs):
-    inputs = Input(shape=(10,), sparse=True)
-    #print(K.is_sparse(inputs))
-    #inputs = K.variable(train_data)
+    inputs = Input(shape=(10,), dtype='float32', sparse=True)
     predictions = Dense(10, activation='linear')(inputs)
     model = Model(outputs=predictions, inputs=inputs)
+    model.summary()
 
-    if K.backend() == 'mxnet':
-        sgd = SGD(lr=0.01, momentum=0.01, lazy_update=False)
+    sgd = SGD(lr=0.01, momentum=0.01)
 
-    elif K.backend() == 'tensorflow':
-        sgd = SGD(lr=0.01, momentum=0.01)
-   
-    model.compile(loss='mse', optimizer=sgd)
+    model.compile(loss='mse', optimizer=sgd, metrics=['accuracy'])
 
     start = time.time()
     model.fit(train_data, train_label,
               epochs=epochs,
               batch_size=batch_size)
 
-    print("Keras-TF Sparse Benchmark Results")
+    print("Keras Sparse Benchmark Results")
+    print("Backend: ", K.backend())
     print("Batch Size")
     print(batch_size)
     print('Total Time')
@@ -41,3 +36,4 @@ def run_benchmark(train_data, train_label, eval_data, eval_label, batch_size, ep
 
     print("Achieved {0:.6f} validation MSE".format(mse[0]))
     print(model.evaluate(eval_data, eval_label, verbose=1, batch_size=batch_size))
+

--- a/benchmark/sparse/linear_regression/keras_sparse_model.py
+++ b/benchmark/sparse/linear_regression/keras_sparse_model.py
@@ -16,7 +16,7 @@ def run_benchmark(train_data, train_label, eval_data, eval_label, batch_size, ep
     model = Model(outputs=predictions, inputs=inputs)
     model.summary()
 
-    sgd = SGD(lr=0.01, momentum=0.01)
+    sgd = SGD(lr=0.1, momentum=0.9)
 
     model.compile(loss='mse', optimizer=sgd, metrics=['accuracy'])
 

--- a/benchmark/sparse/linear_regression/keras_sparse_model.py
+++ b/benchmark/sparse/linear_regression/keras_sparse_model.py
@@ -1,6 +1,7 @@
 """
 Linear Regression model with sparse synthetic data for Keras
 """
+from __future__ import print_function
 
 import time
 
@@ -10,30 +11,37 @@ from keras.optimizers import SGD
 from keras import backend as K
 
 
-def run_benchmark(train_data, train_label, eval_data, eval_label, batch_size, epochs):
-    inputs = Input(shape=(10,), dtype='float32', sparse=True)
-    predictions = Dense(10, activation='linear')(inputs)
-    model = Model(outputs=predictions, inputs=inputs)
+def run_benchmark(train_data, train_label, eval_data, eval_label, batch_size, epochs, start, is_sparse=True):
+    if is_sparse:
+        inputs = Input(batch_shape=(None, train_data.shape[1]), dtype='float32', sparse=True)
+    else:
+        inputs = Input(batch_shape=(None, train_data.shape[1]), dtype='float32', sparse=False)
+
+    predictions = Dense(units=1, activation='linear', kernel_initializer='normal')(inputs)
+    model = Model(inputs=inputs, outputs=predictions)
     model.summary()
 
     sgd = SGD(lr=0.1, momentum=0.9)
 
     model.compile(loss='mse', optimizer=sgd, metrics=['accuracy'])
 
-    start = time.time()
-    model.fit(train_data, train_label,
+    model.fit(train_data,
+              train_label,
               epochs=epochs,
-              batch_size=batch_size)
+              batch_size=batch_size, verbose=1)
 
-    print("Keras Sparse Benchmark Results")
-    print("Backend: ", K.backend())
-    print("Batch Size")
-    print(batch_size)
-    print('Total Time')
-    print(time.time() - start)
+    print("Keras Benchmark Results")
+    if is_sparse:
+        print("Dataset: Synthetic Sparse Data")
+    else:
+        print("Dataset: Synthetic Dense Data")
+    print("Backend: ", K.backend().capitalize())
+    print("Batch Size: ", batch_size)
+    print("Total Time: ", time.time() - start)
 
     mse = model.evaluate(eval_data, eval_label, verbose=0, batch_size=batch_size)
 
     print("Achieved {0:.6f} validation MSE".format(mse[0]))
     print(model.evaluate(eval_data, eval_label, verbose=1, batch_size=batch_size))
+
 

--- a/benchmark/sparse/linear_regression/keras_sparse_model.py
+++ b/benchmark/sparse/linear_regression/keras_sparse_model.py
@@ -5,18 +5,22 @@ from __future__ import print_function
 
 import time
 
-from keras import Model
-from keras.layers import Dense, Input
+from keras import Model, Sequential
+from keras.layers import Dense, Input, Activation
 from keras.optimizers import SGD
 from keras import backend as K
 
 
-def run_benchmark(train_data, train_label, eval_data, eval_label, batch_size, epochs, start, is_sparse=True):
-    if is_sparse:
-        inputs = Input(batch_shape=(None, train_data.shape[1]), dtype='float32', sparse=True)
-    else:
-        inputs = Input(batch_shape=(None, train_data.shape[1]), dtype='float32', sparse=False)
+def _validate_backend():
+    if K.backend() != 'mxnet' and K.backend() != 'tensorflow':
+        raise NotImplementedError('This benchmark script only supports MXNet and TensorFlow backend')
 
+
+def run_benchmark(train_data, train_label, eval_data, eval_label, batch_size, epochs, start):
+
+    _validate_backend()
+
+    inputs = Input(batch_shape=(None, train_data.shape[1]), dtype='float32', sparse=True)
     predictions = Dense(units=1, activation='linear', kernel_initializer='normal')(inputs)
     model = Model(inputs=inputs, outputs=predictions)
     model.summary()
@@ -31,10 +35,7 @@ def run_benchmark(train_data, train_label, eval_data, eval_label, batch_size, ep
               batch_size=batch_size, verbose=1)
 
     print("Keras Benchmark Results")
-    if is_sparse:
-        print("Dataset: Synthetic Sparse Data")
-    else:
-        print("Dataset: Synthetic Dense Data")
+    print("Dataset: Synthetic Sparse Data")
     print("Backend: ", K.backend().capitalize())
     print("Batch Size: ", batch_size)
     print("Total Time: ", time.time() - start)
@@ -43,5 +44,3 @@ def run_benchmark(train_data, train_label, eval_data, eval_label, batch_size, ep
 
     print("Achieved {0:.6f} validation MSE".format(mse[0]))
     print(model.evaluate(eval_data, eval_label, verbose=1, batch_size=batch_size))
-
-

--- a/benchmark/sparse/linear_regression/keras_tf_model.py
+++ b/benchmark/sparse/linear_regression/keras_tf_model.py
@@ -7,16 +7,24 @@ import time
 from keras import Model
 from keras.layers import Dense, Input
 from keras.optimizers import SGD
+from keras import backend as K
+import mxnet as mx
 
 
 def run_benchmark(train_data, train_label, eval_data, eval_label, batch_size, epochs):
     inputs = Input(shape=(10,), sparse=True)
+    #print(K.is_sparse(inputs))
+    #inputs = K.variable(train_data)
     predictions = Dense(10, activation='linear')(inputs)
-    model = Model(input=inputs, output=predictions)
+    model = Model(outputs=predictions, inputs=inputs)
 
-    sgd = SGD(lr=0.1, momentum=0.9)
+    if K.backend() == 'mxnet':
+        sgd = SGD(lr=0.01, momentum=0.01, lazy_update=False)
 
-    model.compile(loss='mse', optimizer=sgd, metrics=['accuracy'])
+    elif K.backend() == 'tensorflow':
+        sgd = SGD(lr=0.01, momentum=0.01)
+   
+    model.compile(loss='mse', optimizer=sgd)
 
     start = time.time()
     model.fit(train_data, train_label,

--- a/benchmark/sparse/linear_regression/mxnet_sparse_model.py
+++ b/benchmark/sparse/linear_regression/mxnet_sparse_model.py
@@ -1,5 +1,6 @@
 """
 Linear Regression model with sparse synthetic data for MXNet
+https://mxnet.incubator.apache.org/tutorials/sparse/train.html
 """
 
 import time
@@ -14,7 +15,8 @@ def run_benchmark(train_data, train_label, eval_data, eval_label, batch_size, ep
 
     X = mx.sym.Variable('data', stype='csr')
     weight = mx.symbol.Variable('weight', stype='row_sparse', shape=(train_data.shape[1], 1))
-    pred = mx.sym.sparse.dot(X, weight)
+    bias = mx.symbol.Variable("bias", shape=(1,))
+    pred = mx.symbol.broadcast_add(mx.sym.sparse.dot(X, weight), bias)
 
     Y = mx.symbol.Variable('label')
     lro = mx.sym.LinearRegressionOutput(data=pred, label=Y, name='lro')

--- a/benchmark/sparse/linear_regression/mxnet_sparse_model.py
+++ b/benchmark/sparse/linear_regression/mxnet_sparse_model.py
@@ -2,6 +2,7 @@
 Linear Regression model with sparse synthetic data for MXNet
 https://mxnet.incubator.apache.org/tutorials/sparse/train.html
 """
+from __future__ import print_function
 
 import time
 import mxnet as mx

--- a/benchmark/sparse/linear_regression/mxnet_sparse_model.py
+++ b/benchmark/sparse/linear_regression/mxnet_sparse_model.py
@@ -6,21 +6,17 @@ import time
 import mxnet as mx
 
 
-def run_benchmark(train_data, train_label, eval_data, eval_label, batch_size, epochs, start, is_sparse=True):
+def run_benchmark(train_data, train_label, eval_data, eval_label, batch_size, epochs, start):
     train_iter = mx.io.NDArrayIter(train_data, train_label, batch_size, last_batch_handle='discard', label_name='label')
 
     eval_iter = mx.io.NDArrayIter(eval_data, eval_label, batch_size=batch_size,
                                   label_name='label', last_batch_handle='discard')
 
-    if is_sparse:
-        X = mx.sym.Variable('data', stype='csr')
-        weight = mx.symbol.Variable('weight', stype='row_sparse', shape=(train_data.shape[1], 1))
-    else:
-        X = mx.sym.Variable('data', stype='default')
-        weight = mx.symbol.Variable('weight', stype='default', shape=(train_data.shape[1], 1))
+    X = mx.sym.Variable('data', stype='csr')
+    weight = mx.symbol.Variable('weight', stype='row_sparse', shape=(train_data.shape[1], 1))
+    pred = mx.sym.sparse.dot(X, weight)
 
     Y = mx.symbol.Variable('label')
-    pred = mx.sym.sparse.dot(X, weight)
     lro = mx.sym.LinearRegressionOutput(data=pred, label=Y, name='lro')
 
     # Create module
@@ -50,10 +46,7 @@ def run_benchmark(train_data, train_label, eval_data, eval_label, batch_size, ep
         print("Epoch %d, Metric = %s" % (epoch, metric.get()))
 
     print("MXNet Sparse Benchmark Results")
-    if is_sparse:
-        print("Dataset: Synthetic Sparse Data")
-    else:
-        print("Dataset: Synthetic Dense Data")
+    print("Dataset: Synthetic Sparse Data")
     print("Batch Size")
     print(batch_size)
     print("Total Time")

--- a/benchmark/sparse/linear_regression/results.md
+++ b/benchmark/sparse/linear_regression/results.md
@@ -21,6 +21,15 @@
 |  C5.18X Large |   0  | 64  | 13.13 sec | 19.20 sec |
 |  C5.18X Large |   0  | 128  | 5.72 sec | 9.86 sec |
 
+### Results 
+| Instance Type | GPUs  | Batch Size  | MXNet (Time/Epoch) | Keras-MXNet (Time/Epoch)| Keras-TensorFlow (Time/Epoch)  |
+|-----|-----|-----|Sparse|Sparse| Sparse|
+|-----|-----|-----|-----|-----|-----|
+|  MacOS |   0  | 16  | 51.15 sec | 71.85 sec |
+|  MacOS |   0  | 32 | 20.82 sec | 54.31 sec |
+|  MacOS |   0  | 64  | 13.13 sec | 19.20 sec |
+|  MacOS |   0  | 128  | 5.72 sec | 9.86 sec |
+
 ### Note
 For reproducing above results set seed to `7` by adding this line in the `run_sparse_benchmark` script - `np.random.seed(7)`
 

--- a/benchmark/sparse/linear_regression/results.md
+++ b/benchmark/sparse/linear_regression/results.md
@@ -16,12 +16,13 @@
 ### Results 
 ##### Sparse data
 ###### Using 25 epochs
+###### Benchmark results calculated using an average of 5 runs
 | Instance Type | GPUs  | Batch Size  | MXNet (Time/Epoch) | Keras-MXNet (Time/Epoch) | Keras-TensorFlow (Time/Epoch)  |
 |-----|-----|-----|-----|-----|-----|
-| C5.18XLarge |   0  | 16  | 52.89 sec | 334.32 sec | 237.28 sec |
-| C5.18XLarge |   0  | 32 | 27.54 sec | 177.99 sec | 124.59 sec |
-| C5.18XLarge |   0  | 64  | 13.78 sec | 85.22 sec | 60.86 sec |
-| C5.18XLarge |   0  | 128  | 6.49 sec | 42.45 sec |  31.09 se |
+| C5.18XLarge |   0  | 16  | 4.97 sec | 31.02 sec | 21.05 sec |
+| C5.18XLarge |   0  | 32 | 2.48 sec | 15.36 sec | 10.68 sec |
+| C5.18XLarge |   0  | 64  | 1.36 sec | 8.12 sec | 5.41 sec |
+| C5.18XLarge |   0  | 128  | 0.69 sec | 3.89 sec |  2.86 sec |
 
 
 ### Note

--- a/benchmark/sparse/linear_regression/results.md
+++ b/benchmark/sparse/linear_regression/results.md
@@ -9,31 +9,24 @@
 | Dataset          | Synthetic(Randomly generated)                                |
 | :--------------- | :----------------------------------------------------------- |
 | Keras            | v2.2.2                                                      |
-| TensorFlow       | v1.9.0                                                      |
-| MXNet            | v1.2.1                                                       |
+| TensorFlow       | v1.10.0                                                      |
+| MXNet            | v1.3.0                                                      |
 
 
 ### Results 
-| Instance Type | GPUs  | Batch Size  | MXNet (Time/Epoch) | Keras-TensorFlow (Time/Epoch)  |
-|-----|-----|-----|----- |-----|
-|  C5.18X Large |   0  | 16  | 51.15 sec | 71.85 sec |
-|  C5.18X Large |   0  | 32 | 20.82 sec | 54.31 sec |
-|  C5.18X Large |   0  | 64  | 13.13 sec | 19.20 sec |
-|  C5.18X Large |   0  | 128  | 5.72 sec | 9.86 sec |
-
-### Results 
-| Instance Type | GPUs  | Batch Size  | MXNet (Time/Epoch) | Keras-MXNet (Time/Epoch)| Keras-TensorFlow (Time/Epoch)  |
-|-----|-----|-----|Sparse|Sparse| Sparse|
+##### Sparse data
+###### Using 25 epochs
+| Instance Type | GPUs  | Batch Size  | MXNet (Time/Epoch) | Keras-MXNet (Time/Epoch) | Keras-TensorFlow (Time/Epoch)  |
 |-----|-----|-----|-----|-----|-----|
-|  MacOS |   0  | 16  | 51.15 sec | 71.85 sec |
-|  MacOS |   0  | 32 | 20.82 sec | 54.31 sec |
-|  MacOS |   0  | 64  | 13.13 sec | 19.20 sec |
-|  MacOS |   0  | 128  | 5.72 sec | 9.86 sec |
+| C5.18XLarge |   0  | 16  | 52.89 sec | 334.32 sec | 237.28 sec |
+| C5.18XLarge |   0  | 32 | 27.54 sec | 177.99 sec | 124.59 sec |
+| C5.18XLarge |   0  | 64  | 13.78 sec | 85.22 sec | 60.86 sec |
+| C5.18XLarge |   0  | 128  | 6.49 sec | 42.45 sec |  31.09 se |
+
 
 ### Note
 For reproducing above results set seed to `7` by adding this line in the `run_sparse_benchmark` script - `np.random.seed(7)`
-
-Run the file as `python run_sparse_benchmark.py --batch=128 --epochs=1000`
+Run the file as `python run_sparse_benchmark.py`
 
 ### References
 MXNet supports sparse data in 2 NDArray formats - CSRNDArray and RowSparseNDArray which are defined in `mxnet.ndarray.sparse` package

--- a/benchmark/sparse/linear_regression/run_sparse_benchmark.py
+++ b/benchmark/sparse/linear_regression/run_sparse_benchmark.py
@@ -3,38 +3,88 @@ Prepare data for running benchmark on sparse linear regression model
 """
 
 import argparse
+import time
 
 import keras_sparse_model
-import mxnet_sparse_model
 import mxnet as mx
+import mxnet_sparse_model
 from scipy import sparse
+
+import numpy as np
+
+from keras.utils.data_utils import prepare_sliced_sparse_data
 
 
 def invoke_benchmark(batch_size, epochs):
-    train_data = mx.test_utils.rand_ndarray(shape=(1000, 10), stype='csr')
-    train_label = 3 * train_data
-    eval_data = mx.test_utils.rand_ndarray(shape=(1000, 10), stype='csr')
-    eval_label = 3 * eval_data
+    np.random.rand(7)
 
-    print("Running Keras sparse benchmark script")
+    feature_dimension = 100
+    train_data = mx.test_utils.rand_ndarray((100000, feature_dimension), 'csr', 0.01)
+    target_weight = mx.nd.arange(1, feature_dimension + 1).reshape((feature_dimension, 1))
+    train_label = mx.nd.dot(train_data, target_weight)
+    eval_data = train_data
+    eval_label = mx.nd.dot(eval_data, target_weight)
+
+    train_data = prepare_sliced_sparse_data(train_data, batch_size)
+    train_label = prepare_sliced_sparse_data(train_label, batch_size)
+    eval_data = prepare_sliced_sparse_data(eval_data, batch_size)
+    eval_label = prepare_sliced_sparse_data(eval_label, batch_size)
+
+    start = time.time()
+    print("Running Keras benchmark script on sparse data")
     keras_sparse_model.run_benchmark(train_data=sparse.csr_matrix(train_data.asnumpy()),
                                      train_label=sparse.csr_matrix(train_label.asnumpy()),
                                      eval_data=sparse.csr_matrix(eval_data.asnumpy()),
                                      eval_label=sparse.csr_matrix(eval_label.asnumpy()),
-                                     batch_size=int(batch_size),
-                                     epochs=int(epochs))
+                                     batch_size=batch_size,
+                                     epochs=epochs,
+                                     start=start,
+                                     is_sparse=True)
 
-    print("Running MXNet sparse benchmark script")
-    mxnet_sparse_model.run_benchmark(train_data=train_data, train_label=train_label, eval_data=eval_data,
-                                     eval_label=eval_label, batch_size=int(batch_size), epochs=int(epochs))
+    start = time.time()
+    print("Running MXNet benchmark script on sparse data")
+    mxnet_sparse_model.run_benchmark(train_data=train_data,
+                                     train_label=train_label,
+                                     eval_data=eval_data,
+                                     eval_label=eval_label,
+                                     batch_size=batch_size,
+                                     epochs=epochs,
+                                     start=start,
+                                     is_sparse=True)
+
+    train_data = train_data.tostype('default')
+    train_label = train_label.tostype('default')
+    eval_label = eval_label.tostype('default')
+
+    start = time.time()
+    print("Running Keras benchmark script on dense data")
+    keras_sparse_model.run_benchmark(train_data=train_data.asnumpy(),
+                                     train_label=train_label.asnumpy(),
+                                     eval_data=eval_data.asnumpy(),
+                                     eval_label=eval_label.asnumpy(),
+                                     batch_size=batch_size,
+                                     epochs=epochs,
+                                     start=start,
+                                     is_sparse=False)
+
+    start = time.time()
+    print("Running MXNet benchmark script on dense data")
+    mxnet_sparse_model.run_benchmark(train_data=train_data,
+                                     train_label=train_label,
+                                     eval_data=eval_data,
+                                     eval_label=eval_label,
+                                     batch_size=batch_size,
+                                     epochs=epochs,
+                                     start=start,
+                                     is_sparse=False)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--batch', default=1,
-                        help='Batch of data to be processed for training')
-    parser.add_argument('--epochs', default=10,
-                        help='Number of epochs to train the model on. Set epochs>=1000 for the best results')
+    parser.add_argument("--batch", default=128,
+                        help="Batch of data to be processed for training")
+    parser.add_argument("--epochs", default=1000,
+                        help="Number of epochs to train the model on. Set epochs>=1000 for the best results")
     args = parser.parse_args()
 
-    invoke_benchmark(args.batch, args.epochs)
+    invoke_benchmark(int(args.batch), int(args.epochs))

--- a/benchmark/sparse/linear_regression/run_sparse_benchmark.py
+++ b/benchmark/sparse/linear_regression/run_sparse_benchmark.py
@@ -4,7 +4,6 @@ Prepare data for running benchmark on sparse linear regression model
 
 import argparse
 import time
-import numpy as np
 
 import keras_sparse_model
 import mxnet as mx
@@ -16,10 +15,7 @@ from keras.utils.data_utils import prepare_sliced_sparse_data
 
 
 def invoke_benchmark(batch_size, epochs):
-    # Fix seed for randomness
-    np.random.rand(7)
-
-    feature_dimension = 100
+    feature_dimension = 1000
     train_data = mx.test_utils.rand_ndarray((100000, feature_dimension), 'csr', 0.01)
     target_weight = mx.nd.arange(1, feature_dimension + 1).reshape((feature_dimension, 1))
     train_label = mx.nd.dot(train_data, target_weight)

--- a/benchmark/sparse/linear_regression/run_sparse_benchmark.py
+++ b/benchmark/sparse/linear_regression/run_sparse_benchmark.py
@@ -31,7 +31,7 @@ def invoke_benchmark(batch_size, epochs):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--batch', default=128,
+    parser.add_argument('--batch', default=1,
                         help='Batch of data to be processed for training')
     parser.add_argument('--epochs', default=1000,
                         help='Number of epochs to train the model on. Set epochs>=1000 for the best results')

--- a/benchmark/sparse/linear_regression/run_sparse_benchmark.py
+++ b/benchmark/sparse/linear_regression/run_sparse_benchmark.py
@@ -4,9 +4,9 @@ Prepare data for running benchmark on sparse linear regression model
 
 import argparse
 
-import keras_tf_model
-import mxnet as mx
+import keras_sparse_model
 import mxnet_sparse_model
+import mxnet as mx
 from scipy import sparse
 
 
@@ -16,13 +16,13 @@ def invoke_benchmark(batch_size, epochs):
     eval_data = mx.test_utils.rand_ndarray(shape=(1000, 10), stype='csr')
     eval_label = 3 * eval_data
 
-    print("Running Keras-TF sparse benchmark script")
-    keras_tf_model.run_benchmark(train_data=sparse.csr_matrix(train_data.asnumpy()),
-                                 train_label=sparse.csr_matrix(train_label.asnumpy()),
-                                 eval_data=sparse.csr_matrix(eval_data.asnumpy()),
-                                 eval_label=sparse.csr_matrix(eval_label.asnumpy()),
-                                 batch_size=int(batch_size),
-                                 epochs=int(epochs))
+    print("Running Keras sparse benchmark script")
+    keras_sparse_model.run_benchmark(train_data=sparse.csr_matrix(train_data.asnumpy()),
+                                     train_label=sparse.csr_matrix(train_label.asnumpy()),
+                                     eval_data=sparse.csr_matrix(eval_data.asnumpy()),
+                                     eval_label=sparse.csr_matrix(eval_label.asnumpy()),
+                                     batch_size=int(batch_size),
+                                     epochs=int(epochs))
 
     print("Running MXNet sparse benchmark script")
     mxnet_sparse_model.run_benchmark(train_data=train_data, train_label=train_label, eval_data=eval_data,
@@ -33,7 +33,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--batch', default=1,
                         help='Batch of data to be processed for training')
-    parser.add_argument('--epochs', default=1000,
+    parser.add_argument('--epochs', default=10,
                         help='Number of epochs to train the model on. Set epochs>=1000 for the best results')
     args = parser.parse_args()
 

--- a/benchmark/sparse/linear_regression/run_sparse_benchmark.py
+++ b/benchmark/sparse/linear_regression/run_sparse_benchmark.py
@@ -1,6 +1,7 @@
 """
 Prepare data for running benchmark on sparse linear regression model
 """
+from __future__ import print_function
 
 import argparse
 import time

--- a/benchmark/sparse/linear_regression/run_sparse_benchmark.py
+++ b/benchmark/sparse/linear_regression/run_sparse_benchmark.py
@@ -4,16 +4,14 @@ Prepare data for running benchmark on sparse linear regression model
 
 import argparse
 import time
+import numpy as np
 
-import os
 import keras_sparse_model
 import mxnet as mx
 import mxnet_sparse_model
 from scipy import sparse
+
 from keras import backend as K
-
-import numpy as np
-
 from keras.utils.data_utils import prepare_sliced_sparse_data
 
 
@@ -33,33 +31,16 @@ def invoke_benchmark(batch_size, epochs):
     eval_data = prepare_sliced_sparse_data(eval_data, batch_size)
     eval_label = prepare_sliced_sparse_data(eval_label, batch_size)
 
-    os.environ['KERAS_BACKEND'] = 'mxnet'
     print("Running Keras benchmark script on sparse data")
-    print("Using MXNet Backend")
-    start = time.time()
+    print("Using Backend: ", K.backend())
     keras_sparse_model.run_benchmark(train_data=sparse.csr_matrix(train_data.asnumpy()),
                                      train_label=sparse.csr_matrix(train_label.asnumpy()),
                                      eval_data=sparse.csr_matrix(eval_data.asnumpy()),
                                      eval_label=sparse.csr_matrix(eval_label.asnumpy()),
                                      batch_size=batch_size,
                                      epochs=epochs,
-                                     start=start,
-                                     is_sparse=True)
+                                     start=time.time())
 
-    os.environ['KERAS_BACKEND'] = 'tensorflow'
-    print("Running Keras benchmark script on sparse data")
-    print("Using Tensorflow Backend")
-    start = time.time()
-    keras_sparse_model.run_benchmark(train_data=sparse.csr_matrix(train_data.asnumpy()),
-                                     train_label=sparse.csr_matrix(train_label.asnumpy()),
-                                     eval_data=sparse.csr_matrix(eval_data.asnumpy()),
-                                     eval_label=sparse.csr_matrix(eval_label.asnumpy()),
-                                     batch_size=batch_size,
-                                     epochs=epochs,
-                                     start=start,
-                                     is_sparse=True)
-
-    start = time.time()
     print("Running MXNet benchmark script on sparse data")
     mxnet_sparse_model.run_benchmark(train_data=train_data,
                                      train_label=train_label,
@@ -67,57 +48,14 @@ def invoke_benchmark(batch_size, epochs):
                                      eval_label=eval_label,
                                      batch_size=batch_size,
                                      epochs=epochs,
-                                     start=start,
-                                     is_sparse=True)
-
-    train_data = train_data.tostype('default')
-    train_label = train_label.tostype('default')
-    eval_label = eval_label.tostype('default')
-
-    os.environ['KERAS_BACKEND'] = 'mxnet'
-    print("Running Keras benchmark script on dense data")
-    print("Using backend: ", K.backend())
-    start = time.time()
-    keras_sparse_model.run_benchmark(train_data=train_data.asnumpy(),
-                                     train_label=train_label.asnumpy(),
-                                     eval_data=eval_data.asnumpy(),
-                                     eval_label=eval_label.asnumpy(),
-                                     batch_size=batch_size,
-                                     epochs=epochs,
-                                     start=start,
-                                     is_sparse=False)
-
-    os.environ['KERAS_BACKEND'] = 'tensorflow'
-    print("Running Keras benchmark script on dense data")
-    print("Using backend: ", K.backend())
-    start = time.time()
-    keras_sparse_model.run_benchmark(train_data=train_data.asnumpy(),
-                                     train_label=train_label.asnumpy(),
-                                     eval_data=eval_data.asnumpy(),
-                                     eval_label=eval_label.asnumpy(),
-                                     batch_size=batch_size,
-                                     epochs=epochs,
-                                     start=start,
-                                     is_sparse=False)
-
-    start = time.time()
-    print("Running MXNet benchmark script on dense data")
-    print("Using backend: ", K.backend())
-    mxnet_sparse_model.run_benchmark(train_data=train_data,
-                                     train_label=train_label,
-                                     eval_data=eval_data,
-                                     eval_label=eval_label,
-                                     batch_size=batch_size,
-                                     epochs=epochs,
-                                     start=start,
-                                     is_sparse=False)
+                                     start=time.time())
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--batch", default=128,
                         help="Batch of data to be processed for training")
-    parser.add_argument("--epochs", default=1000,
+    parser.add_argument("--epochs", default=25,
                         help="Number of epochs to train the model on. Set epochs>=1000 for the best results")
     args = parser.parse_args()
 

--- a/benchmark/sparse/linear_regression/run_sparse_benchmark.py
+++ b/benchmark/sparse/linear_regression/run_sparse_benchmark.py
@@ -5,10 +5,12 @@ Prepare data for running benchmark on sparse linear regression model
 import argparse
 import time
 
+import os
 import keras_sparse_model
 import mxnet as mx
 import mxnet_sparse_model
 from scipy import sparse
+from keras import backend as K
 
 import numpy as np
 
@@ -16,6 +18,7 @@ from keras.utils.data_utils import prepare_sliced_sparse_data
 
 
 def invoke_benchmark(batch_size, epochs):
+    # Fix seed for randomness
     np.random.rand(7)
 
     feature_dimension = 100
@@ -30,8 +33,23 @@ def invoke_benchmark(batch_size, epochs):
     eval_data = prepare_sliced_sparse_data(eval_data, batch_size)
     eval_label = prepare_sliced_sparse_data(eval_label, batch_size)
 
-    start = time.time()
+    os.environ['KERAS_BACKEND'] = 'mxnet'
     print("Running Keras benchmark script on sparse data")
+    print("Using MXNet Backend")
+    start = time.time()
+    keras_sparse_model.run_benchmark(train_data=sparse.csr_matrix(train_data.asnumpy()),
+                                     train_label=sparse.csr_matrix(train_label.asnumpy()),
+                                     eval_data=sparse.csr_matrix(eval_data.asnumpy()),
+                                     eval_label=sparse.csr_matrix(eval_label.asnumpy()),
+                                     batch_size=batch_size,
+                                     epochs=epochs,
+                                     start=start,
+                                     is_sparse=True)
+
+    os.environ['KERAS_BACKEND'] = 'tensorflow'
+    print("Running Keras benchmark script on sparse data")
+    print("Using Tensorflow Backend")
+    start = time.time()
     keras_sparse_model.run_benchmark(train_data=sparse.csr_matrix(train_data.asnumpy()),
                                      train_label=sparse.csr_matrix(train_label.asnumpy()),
                                      eval_data=sparse.csr_matrix(eval_data.asnumpy()),
@@ -56,8 +74,23 @@ def invoke_benchmark(batch_size, epochs):
     train_label = train_label.tostype('default')
     eval_label = eval_label.tostype('default')
 
-    start = time.time()
+    os.environ['KERAS_BACKEND'] = 'mxnet'
     print("Running Keras benchmark script on dense data")
+    print("Using backend: ", K.backend())
+    start = time.time()
+    keras_sparse_model.run_benchmark(train_data=train_data.asnumpy(),
+                                     train_label=train_label.asnumpy(),
+                                     eval_data=eval_data.asnumpy(),
+                                     eval_label=eval_label.asnumpy(),
+                                     batch_size=batch_size,
+                                     epochs=epochs,
+                                     start=start,
+                                     is_sparse=False)
+
+    os.environ['KERAS_BACKEND'] = 'tensorflow'
+    print("Running Keras benchmark script on dense data")
+    print("Using backend: ", K.backend())
+    start = time.time()
     keras_sparse_model.run_benchmark(train_data=train_data.asnumpy(),
                                      train_label=train_label.asnumpy(),
                                      eval_data=eval_data.asnumpy(),
@@ -69,6 +102,7 @@ def invoke_benchmark(batch_size, epochs):
 
     start = time.time()
     print("Running MXNet benchmark script on dense data")
+    print("Using backend: ", K.backend())
     mxnet_sparse_model.run_benchmark(train_data=train_data,
                                      train_label=train_label,
                                      eval_data=eval_data,

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -4222,24 +4222,25 @@ def dfs_get_bind_values(node_start):
      # Returns
         List of binding Tensor values in the computation graph.
     """
-    stack_list = []
-    visited = set()
-    stack_list.append(node_start)
-    while len(stack_list) > 0:
-        cur_node = stack_list.pop()
-        if cur_node in visited:
-            continue
-        visited.add(cur_node)
-        next_nodes = cur_node.get_neighbor()
-        for i in next_nodes:
-            if i in visited:
+    if node_start is not None:
+        stack_list = []
+        visited = set()
+        stack_list.append(node_start)
+        while len(stack_list) > 0:
+            cur_node = stack_list.pop()
+            if cur_node in visited:
                 continue
-            else:
-                stack_list.append(i)
-    bind_values = {}
-    for key in visited:
-        bind_values.update(key.get_bind_values())
-    return bind_values
+            visited.add(cur_node)
+            next_nodes = cur_node.get_neighbor()
+            for i in next_nodes:
+                if i in visited:
+                    continue
+                else:
+                    stack_list.append(i)
+        bind_values = {}
+        for key in visited:
+            bind_values.update(key.get_bind_values())
+        return bind_values
 
 
 def _forward_pass(x):

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -4222,25 +4222,24 @@ def dfs_get_bind_values(node_start):
      # Returns
         List of binding Tensor values in the computation graph.
     """
-    if node_start is not None:
-        stack_list = []
-        visited = set()
-        stack_list.append(node_start)
-        while len(stack_list) > 0:
-            cur_node = stack_list.pop()
-            if cur_node in visited:
+    stack_list = []
+    visited = set()
+    stack_list.append(node_start)
+    while len(stack_list) > 0:
+        cur_node = stack_list.pop()
+        if cur_node in visited:
+            continue
+        visited.add(cur_node)
+        next_nodes = cur_node.get_neighbor()
+        for i in next_nodes:
+            if i in visited:
                 continue
-            visited.add(cur_node)
-            next_nodes = cur_node.get_neighbor()
-            for i in next_nodes:
-                if i in visited:
-                    continue
-                else:
-                    stack_list.append(i)
-        bind_values = {}
-        for key in visited:
-            bind_values.update(key.get_bind_values())
-        return bind_values
+            else:
+                stack_list.append(i)
+    bind_values = {}
+    for key in visited:
+        bind_values.update(key.get_bind_values())
+    return bind_values
 
 
 def _forward_pass(x):

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -5057,6 +5057,7 @@ def get_model():
 
                 batch = mx.io.DataBatch(data=data, label=label, bucket_key='train',
                                         provide_data=data_shapes, provide_label=label_shapes)
+
                 self._module.forward_backward(batch)
                 self._module.update()
                 self._update(self._train_updates)

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import math
 import hashlib
 import multiprocessing as mp
 import os
@@ -297,6 +298,13 @@ def validate_file(fpath, file_hash, algorithm='auto', chunk_size=65535):
         return True
     else:
         return False
+
+
+def prepare_sliced_sparse_data(data, batch_size):
+    index = np.arange(np.shape(data)[0])
+    np.random.shuffle(index)
+    n = math.floor(data.shape[0] / batch_size)
+    return data[:n * batch_size]
 
 
 class Sequence(object):

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -304,7 +304,7 @@ def prepare_sliced_sparse_data(data, batch_size):
     index = np.arange(np.shape(data)[0])
     np.random.shuffle(index)
     n = math.floor(data.shape[0] / batch_size)
-    return data[:n * batch_size]
+    return data[:n*batch_size]
 
 
 class Sequence(object):

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -305,6 +305,8 @@ def prepare_sliced_sparse_data(data, batch_size):
     if data is None or data.shape[0] < batch_size:
         warnings.warn('MXNet Backend: Cannot slice data')
         return data
+    elif hasattr(data, 'tocoo'):  # Convert scipy sparse matrix to numpy array for slicing
+        data = data.toarray()
     n = int(math.floor(data.shape[0] / batch_size))
     return data[:n * batch_size]
 

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -19,6 +19,7 @@ from abc import abstractmethod
 from contextlib import closing
 from multiprocessing.pool import ThreadPool
 
+import warnings
 import numpy as np
 import six
 from six.moves.urllib.error import HTTPError
@@ -301,6 +302,9 @@ def validate_file(fpath, file_hash, algorithm='auto', chunk_size=65535):
 
 
 def prepare_sliced_sparse_data(data, batch_size):
+    if data is None or data.shape[0] < batch_size:
+        warnings.warn('MXNet Backend: Cannot slice data')
+        return data
     n = int(math.floor(data.shape[0] / batch_size))
     return data[:n * batch_size]
 

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -301,10 +301,8 @@ def validate_file(fpath, file_hash, algorithm='auto', chunk_size=65535):
 
 
 def prepare_sliced_sparse_data(data, batch_size):
-    index = np.arange(np.shape(data)[0])
-    np.random.shuffle(index)
-    n = math.floor(data.shape[0] / batch_size)
-    return data[:n*batch_size]
+    n = int(math.floor(data.shape[0] / batch_size))
+    return data[:n * batch_size]
 
 
 class Sequence(object):

--- a/tests/keras/utils/data_utils_test.py
+++ b/tests/keras/utils/data_utils_test.py
@@ -10,13 +10,13 @@ import multiprocessing as mp
 import numpy as np
 import pytest
 import six
+from scipy import sparse
 from six.moves.urllib.parse import urljoin
 from six.moves.urllib.request import pathname2url
 
 from keras.utils import GeneratorEnqueuer
 from keras.utils import OrderedEnqueuer
 from keras.utils import Sequence
-import mxnet as mx
 from keras.utils.data_utils import _hash_file
 from keras.utils.data_utils import get_file
 from keras.utils.data_utils import validate_file
@@ -370,9 +370,20 @@ def test_finite_generator_enqueuer_processes():
     enqueuer.stop()
 
 
+def _generate_test_data():
+    row_ind = np.array([0, 1, 1, 3, 4])
+    col_ind = np.array([0, 2, 4, 3, 4])
+    data = np.array([1, 2, 3, 4, 5], dtype=float)
+    return sparse.coo_matrix((data, (row_ind, col_ind)))
+
+
 def test_prepare_sparse_sliced_data():
-    test_train_data = mx.test_utils.rand_ndarray((10, 10), 'csr', 0.01)
+    row_ind = np.array([0, 1, 1, 3, 4])
+    col_ind = np.array([0, 2, 4, 3, 4])
+    data = np.array([1, 2, 3, 4, 5], dtype=float)
+    test_train_data = sparse.coo_matrix((data, (row_ind, col_ind)))
     batch_size = 3
+
     result = prepare_sliced_sparse_data(test_train_data, batch_size)
 
     assert int(result.shape[0]) % batch_size == 0
@@ -388,9 +399,12 @@ def test_prepare_sparse_sliced_data_no_input():
 
 
 def test_prepare_sparse_sliced_data_incorrect_dimensions():
-    test_train_data = mx.test_utils.rand_ndarray((2, 2), 'csr', 0.01)
-    batch_size = 5
+    row_ind = np.array([0, 1])
+    col_ind = np.array([0, 2])
+    data = np.array([1, 2], dtype=float)
+    test_train_data = sparse.coo_matrix((data, (row_ind, col_ind)))
 
+    batch_size = 5
     with pytest.warns(UserWarning):  # Warning is thrown when data size is smaller than batch size
         result = prepare_sliced_sparse_data(test_train_data, batch_size)
 


### PR DESCRIPTION
### Summary
Keras-MXNet benchmark script resulted in segmentation fault error initially. Added check to ensure that it doesn't happen. 

`Note` - 
Benchmark script currently works well only with batch size <= (10) train_data.shape[1] size

For dimensions > 10 this is the error we get - 
`
File "benchmark/sparse/linear_regression/run_sparse_benchmark.py", line 40, in <module>
    invoke_benchmark(args.batch, args.epochs)
  File "benchmark/sparse/linear_regression/run_sparse_benchmark.py", line 25, in invoke_benchmark
    epochs=int(epochs))
  File "/Users/kalyanee/Documents/kalyc-keras-1/keras-apache-mxnet/benchmark/sparse/linear_regression/keras_sparse_model.py", line 26, in run_benchmark
    batch_size=batch_size)
  File "/anaconda2/envs/mxnet/lib/python3.4/site-packages/keras_mxnet-2.2.2-py3.4.egg/keras/engine/training.py", line 1037, in fit
  File "/anaconda2/envs/mxnet/lib/python3.4/site-packages/keras_mxnet-2.2.2-py3.4.egg/keras/engine/training_arrays.py", line 199, in fit_loop
  File "/anaconda2/envs/mxnet/lib/python3.4/site-packages/keras_mxnet-2.2.2-py3.4.egg/keras/backend/mxnet_backend.py", line 4982, in train_function
  File "/anaconda2/envs/mxnet/lib/python3.4/site-packages/keras_mxnet-2.2.2-py3.4.egg/keras/backend/mxnet_backend.py", line 4942, in _adjust_module
  File "/anaconda2/envs/mxnet/lib/python3.4/site-packages/mxnet/module/module.py", line 471, in reshape
    self._exec_group.reshape(self._data_shapes, self._label_shapes)
  File "/anaconda2/envs/mxnet/lib/python3.4/site-packages/mxnet/module/executor_group.py", line 382, in reshape
    self.bind_exec(data_shapes, label_shapes, reshape=True)
  File "/anaconda2/envs/mxnet/lib/python3.4/site-packages/mxnet/module/executor_group.py", line 358, in bind_exec
    allow_up_sizing=True, **dict(data_shapes_i + label_shapes_i))
  File "/anaconda2/envs/mxnet/lib/python3.4/site-packages/mxnet/executor.py", line 423, in reshape
    new_arg_dict[name] = arr.reshape(new_shape)
  File "/anaconda2/envs/mxnet/lib/python3.4/site-packages/mxnet/ndarray/sparse.py", line 157, in reshape
    raise NotSupportedForSparseNDArray(self.reshape, None, shape)
mxnet.base.NotSupportedForSparseNDArray: Function reshape with arguments (<class 'tuple'>) is not supported for SparseNDArray and only available in NDArray.
`
### Related Issues

### PR Overview

- [n] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [n] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n]

### Solution
Added workaround for the reshape error by slicing data before training
