### PR TITLE
test PR build with latest mxnet master

### DIFF
--- a/keras_mxnet_ci/nightly-buildspec.yml
+++ b/keras_mxnet_ci/nightly-buildspec.yml
@@ -15,7 +15,7 @@ phases:
       echo "Installing Theano";
       pip install theano;
       pip install pillow;
-      pip install graphviz;
+      pip install --upgrade graphviz;
       pip install pydot;
       echo "Installing Keras from source";
       pip install -e .[visualize,tests];

--- a/keras_mxnet_ci/nightly-buildspec.yml
+++ b/keras_mxnet_ci/nightly-buildspec.yml
@@ -15,8 +15,10 @@ phases:
       echo "Installing Theano";
       pip install theano;
       pip install pillow;
+      sudo apt-get -y install graphviz;
       pip install --upgrade graphviz;
       pip install pydot;
+      pip install nose;
       echo "Installing Keras from source";
       pip install -e .[visualize,tests];
       pip uninstall --yes keras;

--- a/keras_mxnet_ci/nightly-buildspec.yml
+++ b/keras_mxnet_ci/nightly-buildspec.yml
@@ -9,7 +9,7 @@ phases:
       echo "Installing MXNet";
       apt-get update;
       pip install --upgrade pip;
-      pip install mxnet-mkl;
+      pip install mxnet-mkl --pre;
       echo "Installing Tensorflow";
       pip install tensorflow;
       echo "Installing Theano";
@@ -24,8 +24,8 @@ phases:
 
   build:
     commands:
+      echo "Running PEP tests";
+      py.test --pep8 -m pep8 -n0;
       echo "Running Keras Unit Tests and Integration Tests for all the backends";
       py.test tests/ --ignore=tests/keras/utils/;
       py.test tests/keras/utils/;
-      echo "Running PEP tests";
-      py.test --pep8 -m pep8 -n0;

--- a/keras_mxnet_ci/pr-buildspec.yml
+++ b/keras_mxnet_ci/pr-buildspec.yml
@@ -17,8 +17,10 @@ phases:
       echo "Installing Theano";
       pip install theano;
       pip install pillow;
+      sudo apt-get -y install graphviz;
       pip install --upgrade graphviz;
       pip install pydot;
+      pip install nose;
       echo "Installing Keras from source";
       pip install -e .[visualize,tests];
       pip uninstall --yes keras;

--- a/keras_mxnet_ci/pr-buildspec.yml
+++ b/keras_mxnet_ci/pr-buildspec.yml
@@ -11,7 +11,7 @@ phases:
       echo "Installing MXNet";
       apt-get update;
       pip install --upgrade pip;
-      pip install mxnet-mkl;
+      pip install mxnet-mkl --pre;
       echo "Installing Tensorflow";
       pip install tensorflow;
       echo "Installing Theano";

--- a/keras_mxnet_ci/pr-buildspec.yml
+++ b/keras_mxnet_ci/pr-buildspec.yml
@@ -25,8 +25,8 @@ phases:
 
   build:
     commands:
+      echo "Running PEP tests";
+      py.test --pep8 -m pep8 -n0;
       echo "Running Keras Unit Tests and Integration Tests for all the backends";
       py.test tests/ --ignore=tests/keras/utils/;
       py.test tests/keras/utils/;
-      echo "Running PEP tests";
-      py.test --pep8 -m pep8 -n0;

--- a/keras_mxnet_ci/pr-buildspec.yml
+++ b/keras_mxnet_ci/pr-buildspec.yml
@@ -17,7 +17,7 @@ phases:
       echo "Installing Theano";
       pip install theano;
       pip install pillow;
-      pip install graphviz;
+      pip install --upgrade graphviz;
       pip install pydot;
       echo "Installing Keras from source";
       pip install -e .[visualize,tests];


### PR DESCRIPTION
### Summary

- Note this change is directly going to master branch since it's a change on CI
- Changing PR builds to use the latest mxnet master (pip install mxnet-mkl --pre) so development is not blocked by mxnet release. We can test with mxnet latest features in PR build on dev branch
- Nightly build still remains to test with mxnet stable release



