### PR TITLE
Update test_multi_hot_sparse_categorical_crossentropy to use only MXN…

### DIFF
--- a/tests/keras/losses_test.py
+++ b/tests/keras/losses_test.py
@@ -108,7 +108,9 @@ def test_sparse_categorical_crossentropy_4d():
     loss = K.eval(losses.sparse_categorical_crossentropy(y_true, y_pred))
     assert np.isclose(expected_loss, np.mean(loss))
 
-@pytest.mark.skipif(K.backend() != 'mxnet', reason='multi_hot_sparse_categorical_crossentropy is only available in MXNet')
+
+@pytest.mark.skipif(K.backend() != 'mxnet', reason='multi_hot_sparse_categorical_crossentropy is only available '
+                                                   'in MXNet')
 def test_multi_hot_sparse_categorical_crossentropy():
     y_true_np = np.array([[0, 1, 1], [1, 0, 1], [1, 0, 0]])
     y_pred_np = np.array([[0.1, 0.4, 0.5],

--- a/tests/keras/losses_test.py
+++ b/tests/keras/losses_test.py
@@ -108,7 +108,7 @@ def test_sparse_categorical_crossentropy_4d():
     loss = K.eval(losses.sparse_categorical_crossentropy(y_true, y_pred))
     assert np.isclose(expected_loss, np.mean(loss))
 
-
+@pytest.mark.skipif(K.backend() != 'mxnet', reason='multi_hot_sparse_categorical_crossentropy is only available in MXNet')
 def test_multi_hot_sparse_categorical_crossentropy():
     y_true_np = np.array([[0, 1, 1], [1, 0, 1], [1, 0, 0]])
     y_pred_np = np.array([[0.1, 0.4, 0.5],


### PR DESCRIPTION
### Summary
Enable  multi_hot_sparse_categorical_crossentropy unit test only for MXNet backend

### Related Issues
Fixes https://github.com/awslabs/keras-apache-mxnet/issues/180

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [X] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n]
