### PR TITLE
increase timeout limit

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,7 @@ addopts=-v
 # Do not run tests in the build folder
 norecursedirs= build
 
-# Running all tests should take less than 12 minutes.
+# Running all tests should take less than 20 minutes.
 # Otherwise, something went wrong.
 timeout = 1200
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,7 +9,7 @@ norecursedirs= build
 
 # Running all tests should take less than 12 minutes.
 # Otherwise, something went wrong.
-timeout = 720
+timeout = 1200
 
 # PEP-8 The following are ignored:
 # E501 line too long (82 > 79 characters)


### PR DESCRIPTION
### Summary
Recently nightly test failed due to timeout.
keras added this limitation for single unit tests, but we are using different CI systems and instance types.
Increased timeout for a single unit test to 20 mins maximum

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n]
