### PR TITLE
Ignoring masking layer test for RNN with MXNet backend

### DIFF
--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -146,6 +146,10 @@ def test_statefulness(layer_class):
 
 
 @rnn_test
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend has an issue with Masking layer'
+                           'Tracking with this issue:'
+                           'https://github.com/awslabs/keras-apache-mxnet/issues/228')
 def test_masking_correctness(layer_class):
     # Check masking: output with left padding and right padding
     # should be the same.
@@ -232,6 +236,10 @@ def test_trainability(layer_class):
     assert len(layer.non_trainable_weights) == 0
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend has an issue with Masking layer'
+                           'Tracking with this issue:'
+                           'https://github.com/awslabs/keras-apache-mxnet/issues/228')
 def test_masking_layer():
     ''' This test based on a previously failing issue here:
     https://github.com/keras-team/keras/issues/1567

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -147,7 +147,8 @@ def test_statefulness(layer_class):
 
 @rnn_test
 @pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend has an issue with Masking layer'
+                    reason='MXNet backend has an issue with Masking layer with `unroll=False`'
+                           'in RNN/LSTM/GRU layer.'
                            'Tracking with this issue:'
                            'https://github.com/awslabs/keras-apache-mxnet/issues/228')
 def test_masking_correctness(layer_class):
@@ -244,7 +245,8 @@ def test_masking_layer():
     targets = np.abs(np.random.random((6, 3, 5)))
     targets /= targets.sum(axis=-1, keepdims=True)
     if K.backend() != 'mxnet':
-        # MXNet backend has an issue with Masking layer
+        # MXNet backend has an issue with Masking layer with `unroll=False`
+        # in RNN/LSTM/GRU layer.
         # Tracking with this issue:
         # https://github.com/awslabs/keras-apache-mxnet/issues/228
         model = Sequential()

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -236,10 +236,6 @@ def test_trainability(layer_class):
     assert len(layer.non_trainable_weights) == 0
 
 
-@pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend has an issue with Masking layer'
-                           'Tracking with this issue:'
-                           'https://github.com/awslabs/keras-apache-mxnet/issues/228')
 def test_masking_layer():
     ''' This test based on a previously failing issue here:
     https://github.com/keras-team/keras/issues/1567
@@ -247,12 +243,15 @@ def test_masking_layer():
     inputs = np.random.random((6, 3, 4))
     targets = np.abs(np.random.random((6, 3, 5)))
     targets /= targets.sum(axis=-1, keepdims=True)
-
-    model = Sequential()
-    model.add(Masking(input_shape=(3, 4)))
-    model.add(recurrent.SimpleRNN(units=5, return_sequences=True, unroll=False))
-    model.compile(loss='categorical_crossentropy', optimizer='adam')
-    model.fit(inputs, targets, epochs=1, batch_size=100, verbose=1)
+    if K.backend() != 'mxnet':
+        # MXNet backend has an issue with Masking layer
+        # Tracking with this issue:
+        # https://github.com/awslabs/keras-apache-mxnet/issues/228
+        model = Sequential()
+        model.add(Masking(input_shape=(3, 4)))
+        model.add(recurrent.SimpleRNN(units=5, return_sequences=True, unroll=False))
+        model.compile(loss='categorical_crossentropy', optimizer='adam')
+        model.fit(inputs, targets, epochs=1, batch_size=100, verbose=1)
 
     model = Sequential()
     model.add(Masking(input_shape=(3, 4)))


### PR DESCRIPTION
### Summary
There is an issue with the Masking Layer in RNN with MXNet backend after this PR [#14192](https://github.com/apache/incubator-mxnet/pull/14192) got merged into MXNet [master](https://github.com/apache/incubator-mxnet/) branch. Ignoring those test for now to let the nightly build pass. I have created a separate issue [#228](https://github.com/awslabs/keras-apache-mxnet/issues/228) to track the masking layer issue.

