### PR TITLE
fix softmax shape

### DIFF
--- a/keras/activations.py
+++ b/keras/activations.py
@@ -31,6 +31,9 @@ def softmax(x, axis=-1):
         e = K.exp(x - K.max(x, axis=axis, keepdims=True))
         s = K.sum(e, axis=axis, keepdims=True)
         return e / s
+    elif K.backend()=='mxnet' and ndim == 0:
+        # x dim is not inferred yet
+        return K.softmax(x)
     else:
         raise ValueError('Cannot apply softmax to a tensor that is 1D. '
                          'Received input: %s' % x)


### PR DESCRIPTION
https://github.com/apache/incubator-mxnet/pull/14869 fix nightly test failure after unknown dim changed from 0 to -1 in MXNet.
This fix softmax shape check in keras after the change.
requires https://github.com/apache/incubator-mxnet/pull/14869 to go into nightly pip packages to pass CI.