### PR TITLE
ping pytest version in ci

### DIFF
--- a/keras_mxnet_ci/nightly-buildspec-python2.yml
+++ b/keras_mxnet_ci/nightly-buildspec-python2.yml
@@ -19,6 +19,9 @@ phases:
       pip install --upgrade graphviz;
       pip install pydot;
       pip install nose;
+      pip install PyYAML==3.13;
+      pip install pytest==3.6.3;
+      pip install pytest-xdist==1.22.2;
       echo "Installing Keras from source";
       pip install -e .[visualize,tests];
 

--- a/keras_mxnet_ci/nightly-buildspec-python3.yml
+++ b/keras_mxnet_ci/nightly-buildspec-python3.yml
@@ -19,6 +19,9 @@ phases:
       pip3 install --upgrade graphviz;
       pip3 install pydot;
       pip3 install nose;
+      pip3 install PyYAML==3.13;
+      pip3 install pytest==3.6.3;
+      pip3 install pytest-xdist==1.22.2;
       echo "Installing Keras from source";
       pip3 install -e .[visualize,tests];
 


### PR DESCRIPTION
fix nightly build on Python3

keras`setup.py` does not require any version on `pytest` `pyyaml` and `pytest-xdist`. So our  CI is picking up the latest version. However, it's causing tests to fail.

Ping them to older stable versioni resolves the issue. 
