### PR TITLE
ping tf version in ci

### DIFF
--- a/keras_mxnet_ci/nightly-buildspec-python2.yml
+++ b/keras_mxnet_ci/nightly-buildspec-python2.yml
@@ -11,7 +11,7 @@ phases:
       pip install --upgrade pip;
       pip install mxnet --pre;
       echo "Installing Tensorflow";
-      pip install tensorflow;
+      pip install tensorflow==1.15.0;
       echo "Installing Theano";
       pip install theano;
       pip install pillow;

--- a/keras_mxnet_ci/nightly-buildspec-python3.yml
+++ b/keras_mxnet_ci/nightly-buildspec-python3.yml
@@ -11,7 +11,7 @@ phases:
       sudo apt install -y python3-pip;
       pip3 install mxnet --pre;
       echo "Installing Tensorflow";
-      pip3 install tensorflow;
+      pip3 install tensorflow==1.15.0;
       echo "Installing Theano";
       pip3 install theano;
       pip3 install pillow;

--- a/keras_mxnet_ci/pr-buildspec-python2.yml
+++ b/keras_mxnet_ci/pr-buildspec-python2.yml
@@ -13,7 +13,7 @@ phases:
       pip install --upgrade pip;
       pip install mxnet --pre;
       echo "Installing Tensorflow";
-      pip install tensorflow;
+      pip install tensorflow==1.15.0;
       echo "Installing Theano";
       pip install theano;
       pip install pillow;

--- a/keras_mxnet_ci/pr-buildspec-python3.yml
+++ b/keras_mxnet_ci/pr-buildspec-python3.yml
@@ -13,7 +13,7 @@ phases:
       sudo apt install -y python3-pip;
       pip3 install mxnet --pre;
       echo "Installing Tensorflow";
-      pip3 install tensorflow;
+      pip3 install tensorflow==1.15.0;
       echo "Installing Theano";
       pip3 install theano;
       pip3 install pillow;


### PR DESCRIPTION
### Summary
tf 2.0 is breaking ci tests

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n]
