### PR TITLE
update to python 3.7

### DIFF
--- a/keras_mxnet_ci/nightly-buildspec-python2.yml
+++ b/keras_mxnet_ci/nightly-buildspec-python2.yml
@@ -16,7 +16,7 @@ phases:
       pip install theano;
       pip install pillow;
       sudo apt-get -y install graphviz;
-      pip install --upgrade graphviz;
+      pip install graphviz;
       pip install pydot;
       pip install nose;
       pip install PyYAML==3.13;

--- a/keras_mxnet_ci/nightly-buildspec-python3.yml
+++ b/keras_mxnet_ci/nightly-buildspec-python3.yml
@@ -10,26 +10,27 @@ phases:
       git checkout master;
       echo "Installing MXNet";
       apt-get update;
-      sudo apt install -y python3-pip;
-      pip3 install mxnet --pre;
+      sudo apt-get install python3.7-dev;
+      python3.7 -m pip install pip;
+      python3.7 -m pip install mxnet --pre;
       echo "Installing Tensorflow";
-      pip3 install tensorflow==1.15.0;
+      python3.7 -m pip install tensorflow==1.15.0;
       echo "Installing Theano";
-      pip3 install theano;
-      pip3 install pillow;
+      python3.7 -m pip install theano
+      python3.7 -m pip install pillow;
       sudo apt-get -y install graphviz;
-      pip3 install graphviz;
-      pip3 install pydot;
-      pip3 install nose;
-      pip3 install PyYAML==3.13;
-      pip3 install pytest==3.6.3;
-      pip3 install pytest-xdist==1.22.2;
+      python3.7 -m pip install graphviz;
+      python3.7 -m pip install pydot;
+      python3.7 -m pip install nose;
+      python3.7 -m pip install --ignore-installed PyYAML==3.13;
+      python3.7 -m pip install pytest==3.6.3;
+      python3.7 -m pip install pytest-xdist==1.22.2;
       echo "Installing Keras from source";
-      pip3 install -e .[visualize,tests];
+      python3.7 -m pip install -e .[visualize,tests];
 
   build:
     commands:
       echo "Running PEP tests";
       py.test --pep8 -m pep8 -n0;
       echo "Running Keras Unit Tests and Integration Tests for all the backends";
-      python3 -m pytest tests/;
+      python3.7 -m pytest tests/;

--- a/keras_mxnet_ci/nightly-buildspec-python3.yml
+++ b/keras_mxnet_ci/nightly-buildspec-python3.yml
@@ -18,7 +18,7 @@ phases:
       pip3 install theano;
       pip3 install pillow;
       sudo apt-get -y install graphviz;
-      pip3 install --upgrade graphviz;
+      pip3 install graphviz;
       pip3 install pydot;
       pip3 install nose;
       pip3 install PyYAML==3.13;

--- a/keras_mxnet_ci/nightly-buildspec-python3.yml
+++ b/keras_mxnet_ci/nightly-buildspec-python3.yml
@@ -16,7 +16,7 @@ phases:
       echo "Installing Tensorflow";
       python3.7 -m pip install tensorflow==1.15.0;
       echo "Installing Theano";
-      python3.7 -m pip install theano
+      python3.7 -m pip install theano;
       python3.7 -m pip install pillow;
       sudo apt-get -y install graphviz;
       python3.7 -m pip install graphviz;

--- a/keras_mxnet_ci/nightly-buildspec-python3.yml
+++ b/keras_mxnet_ci/nightly-buildspec-python3.yml
@@ -10,7 +10,7 @@ phases:
       git checkout master;
       echo "Installing MXNet";
       apt-get update;
-      sudo apt-get install python3.7-dev;
+      apt-get install python3.7-dev;
       python3.7 -m pip install pip;
       python3.7 -m pip install mxnet --pre;
       echo "Installing Tensorflow";
@@ -18,7 +18,7 @@ phases:
       echo "Installing Theano";
       python3.7 -m pip install theano;
       python3.7 -m pip install pillow;
-      sudo apt-get -y install graphviz;
+      apt-get -y install graphviz;
       python3.7 -m pip install graphviz;
       python3.7 -m pip install pydot;
       python3.7 -m pip install nose;

--- a/keras_mxnet_ci/nightly-buildspec-python3.yml
+++ b/keras_mxnet_ci/nightly-buildspec-python3.yml
@@ -2,6 +2,8 @@ version: 0.2
 
 phases:
   install:
+    runtime-versions:
+      python: 3.7
     commands:
       echo "Checking out master branch";
       git fetch;

--- a/keras_mxnet_ci/pr-buildspec-python2.yml
+++ b/keras_mxnet_ci/pr-buildspec-python2.yml
@@ -18,7 +18,7 @@ phases:
       pip install theano;
       pip install pillow;
       sudo apt-get -y install graphviz;
-      pip install --upgrade graphviz;
+      pip install graphviz;
       pip install pydot;
       pip install nose;
       pip3 install PyYAML==3.13;

--- a/keras_mxnet_ci/pr-buildspec-python3.yml
+++ b/keras_mxnet_ci/pr-buildspec-python3.yml
@@ -20,7 +20,7 @@ phases:
       pip3 install theano;
       pip3 install pillow;
       sudo apt-get -y install graphviz;
-      pip3 install --upgrade graphviz;
+      pip3 install graphviz;
       pip3 install pydot;
       pip3 install nose;
       pip3 install PyYAML==3.13;

--- a/keras_mxnet_ci/pr-buildspec-python3.yml
+++ b/keras_mxnet_ci/pr-buildspec-python3.yml
@@ -12,7 +12,7 @@ phases:
       git checkout pr_test;
       echo "Installing MXNet";
       apt-get update;
-      sudo apt-get install python3.7-dev;
+      apt-get install python3.7-dev;
       python3.7 -m pip install pip;
       python3.7 -m pip install mxnet --pre;
       echo "Installing Tensorflow";
@@ -20,7 +20,7 @@ phases:
       echo "Installing Theano";
       python3.7 -m pip install theano;
       python3.7 -m pip install pillow;
-      sudo apt-get -y install graphviz;
+      apt-get -y install graphviz;
       python3.7 -m pip install graphviz;
       python3.7 -m pip install pydot;
       python3.7 -m pip install nose;

--- a/keras_mxnet_ci/pr-buildspec-python3.yml
+++ b/keras_mxnet_ci/pr-buildspec-python3.yml
@@ -2,6 +2,8 @@ version: 0.2
 
 phases:
   install:
+    runtime-versions:
+      python: 3.7
     commands:
       echo $CODEBUILD_SOURCE_VERSION;
       PRID=$(echo $CODEBUILD_SOURCE_VERSION | sed "s/pr/pull/g");

--- a/keras_mxnet_ci/pr-buildspec-python3.yml
+++ b/keras_mxnet_ci/pr-buildspec-python3.yml
@@ -12,26 +12,27 @@ phases:
       git checkout pr_test;
       echo "Installing MXNet";
       apt-get update;
-      sudo apt install -y python3-pip;
-      pip3 install mxnet --pre;
+      sudo apt-get install python3.7-dev;
+      python3.7 -m pip install pip;
+      python3.7 -m pip install mxnet --pre;
       echo "Installing Tensorflow";
-      pip3 install tensorflow==1.15.0;
+      python3.7 -m pip install tensorflow==1.15.0;
       echo "Installing Theano";
-      pip3 install theano;
-      pip3 install pillow;
+      python3.7 -m pip install theano
+      python3.7 -m pip install pillow;
       sudo apt-get -y install graphviz;
-      pip3 install graphviz;
-      pip3 install pydot;
-      pip3 install nose;
-      pip3 install PyYAML==3.13;
-      pip3 install pytest==3.6.3;
-      pip3 install pytest-xdist==1.22.2;
+      python3.7 -m pip install graphviz;
+      python3.7 -m pip install pydot;
+      python3.7 -m pip install nose;
+      python3.7 -m pip install --ignore-installed PyYAML==3.13;
+      python3.7 -m pip install pytest==3.6.3;
+      python3.7 -m pip install pytest-xdist==1.22.2;
       echo "Installing Keras from source";
-      pip3 install -e .[visualize,tests];
+      python3.7 -m pip install -e .[visualize,tests];
 
   build:
     commands:
       echo "Running PEP tests";
       py.test --pep8 -m pep8 -n0;
       echo "Running Keras Unit Tests and Integration Tests for all the backends";
-      python3 -m pytest tests/;
+      python3.7 -m pytest tests/;

--- a/keras_mxnet_ci/pr-buildspec-python3.yml
+++ b/keras_mxnet_ci/pr-buildspec-python3.yml
@@ -18,7 +18,7 @@ phases:
       echo "Installing Tensorflow";
       python3.7 -m pip install tensorflow==1.15.0;
       echo "Installing Theano";
-      python3.7 -m pip install theano
+      python3.7 -m pip install theano;
       python3.7 -m pip install pillow;
       sudo apt-get -y install graphviz;
       python3.7 -m pip install graphviz;


### PR DESCRIPTION
### Summary

Using Python3.7 for python 3 tests. It seems the latest stable 1.x tensorflow is 1.15 and only available for python3.7 (not 3.6/3.5).
Updated to use python3.7 environment in AWS code build.
change install commands to use python3.7 as the default python3 is python3.5 on the code build environment.

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n]
