### PR TITLE
fix set MXNet context

### DIFF
--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -5224,6 +5224,7 @@ def get_num_gpus():
         return len(gpus)
     return 0
 
+
 class Context:
     """Scope for managing the context/runtime.
 

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -5311,7 +5311,7 @@ class Context:
 
     """
     def __init__(self, ctx):
-        self.scope_ctx = get_model().get_mxnet_context(ctx)
+        self.scope_ctx = _get_mxnet_context(ctx)
 
     def __enter__(self):
         global _CURRENT_SCOPE_CTX

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -5275,7 +5275,16 @@ def get_model():
 
             self.name = kwargs['name']
 
+            # if context in kwargs, remove it before calling super
+            # this is only MXNet specific kwargs
+            context = None
+            if 'context' in kwargs:
+                context = kwargs['context']
+                kwargs.pop('context')
             super(Model, self).__init__(*args, **kwargs)
+            # add context back as kwargs
+            if context:
+                kwargs['context'] = context
 
             if 'context' not in kwargs:
                 kwargs['context'] = None
@@ -5705,7 +5714,7 @@ def get_model():
                                      'call `multi_gpu_model` with `len(gpus) >= 2`. '
                                      'Received: `gpus=%s`' % context)
             elif isinstance(context, str):
-                if not context.lower().startswith('eia'):
+                if not context.lower().startswith(('eia', 'cpu', 'gpu')):
                     raise ValueError('MXNet Backend: Invalid context provided - %s' % context)
             else:
                 if context <= 1:

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -5225,6 +5225,75 @@ def get_num_gpus():
     return 0
 
 
+def _get_mxnet_context(context):
+    # If we are currently under a global scope context,
+    # then it overrides all other local context parameters.
+    global _CURRENT_SCOPE_CTX
+    # Note: _CURRENT_SCOPE_CTX will be None if not in scope.
+    if _CURRENT_SCOPE_CTX:
+        return _CURRENT_SCOPE_CTX
+
+    mxnet_context = []
+
+    if context is None:
+        # If user does not provide any context, if GPUs are detected, by default it runs on first available
+        # GPU device. If not GPUs are detected, then it falls back to CPU.
+        try:
+            gpus = mx.test_utils.list_gpus()
+        except CalledProcessError:
+            gpus = []
+        if gpus and len(gpus) > 0:
+            mxnet_context.append(mx.gpu(gpus[0]))
+        else:
+            mxnet_context.append(mx.current_context())
+    elif isinstance(context, Number):
+        # If user provides number of GPUs to use, set context accordingly.
+        if context == 0:
+            mxnet_context.append(mx.current_context())
+        else:
+            for gpu_id in range(0, context):
+                mxnet_context.append(mx.gpu(gpu_id))
+    elif isinstance(context, str):
+        # If user provides GPU context in the format - "gpu(0)" or "eia" or "eia(0)" i.e., string.
+        if context.lower().startswith('eia('):
+            index = int(context[4:-1])
+            mxnet_context.append(mx.eia(index))
+        elif context.lower().startswith('gpu('):
+            index = int(context[4:-1])
+            mxnet_context.append(mx.gpu(index))
+        elif context.lower() in mx.Context.devstr2type:
+            mxnet_context.append(mx.Context(context.lower()))
+        else:
+            raise ValueError("Invalid MXNet context provided - ", context)
+    else:
+        # If user has provided a list.
+        # List can be:
+        #   1. List of GPU IDs - [0, 1, 2, 3]
+        #   2. List of GPU context strings - ["gpu(0)", "gpu(1)"] or ["gpu0", "gpu1"]
+        #      Or, ["eia(0)", "eia(1)"]
+        for context_name in context:
+            if isinstance(context_name, Number):
+                mxnet_context.append(mx.gpu(context_name))
+            elif context_name.startswith('cpu'):
+                mxnet_context.append(mx.cpu())
+            elif context_name.startswith('gpu('):
+                index = int(context_name[4:-1])
+                mxnet_context.append(mx.gpu(index))
+            elif context_name.startswith('gpu'):
+                index = int(context_name[3:])
+                mxnet_context.append(mx.gpu(index))
+            elif context_name.startswith('eia('):
+                index = int(context_name[4:-1])
+                mxnet_context.append(mx.eia(index))
+            elif context_name.startswith('eia'):
+                index = int(context_name[3:])
+                mxnet_context.append(mx.eia(index))
+            else:
+                raise ValueError("Invalid MXNet context provided - ", context)
+
+    return mxnet_context
+
+
 class Context:
     """Scope for managing the context/runtime.
 
@@ -5276,16 +5345,7 @@ def get_model():
 
             self.name = kwargs['name']
 
-            # if context in kwargs, remove it before calling super
-            # this is only MXNet specific kwargs
-            context = None
-            if 'context' in kwargs:
-                context = kwargs['context']
-                kwargs.pop('context')
             super(Model, self).__init__(*args, **kwargs)
-            # add context back as kwargs
-            if context:
-                kwargs['context'] = context
 
             if 'context' not in kwargs:
                 kwargs['context'] = None
@@ -5293,7 +5353,7 @@ def get_model():
             if 'kvstore' not in kwargs:
                 kwargs['kvstore'] = 'device'
 
-            self._context = self.get_mxnet_context(kwargs['context'])
+            self._context = _get_mxnet_context(kwargs['context'])
             self._kvstore = kwargs['kvstore']
 
             self._data_names = None
@@ -5341,7 +5401,7 @@ def get_model():
 
             # If context is passed in kwargs
             if 'context' in kwargs:
-                self._context = self.get_mxnet_context(kwargs['context'])
+                self._context = _get_mxnet_context(kwargs['context'])
 
             if self.built:
                 self._num_data = len(self.inputs)
@@ -5633,75 +5693,6 @@ def get_model():
                     context=self._context,
                     fixed_param_names=self._fixed_weights)
 
-        @staticmethod
-        def get_mxnet_context(context):
-            # If we are currently under a global scope context,
-            # then it overrides all other local context parameters.
-            global _CURRENT_SCOPE_CTX
-            # Note: _CURRENT_SCOPE_CTX will be None if not in scope.
-            if _CURRENT_SCOPE_CTX:
-                return _CURRENT_SCOPE_CTX
-
-            mxnet_context = []
-
-            if context is None:
-                # If user does not provide any context, if GPUs are detected, by default it runs on first available
-                # GPU device. If not GPUs are detected, then it falls back to CPU.
-                try:
-                    gpus = mx.test_utils.list_gpus()
-                except CalledProcessError:
-                    gpus = []
-                if gpus and len(gpus) > 0:
-                    mxnet_context.append(mx.gpu(gpus[0]))
-                else:
-                    mxnet_context.append(mx.current_context())
-            elif isinstance(context, Number):
-                # If user provides number of GPUs to use, set context accordingly.
-                if context == 0:
-                    mxnet_context.append(mx.current_context())
-                else:
-                    for gpu_id in range(0, context):
-                        mxnet_context.append(mx.gpu(gpu_id))
-            elif isinstance(context, str):
-                # If user provides GPU context in the format - "gpu(0)" or "eia" or "eia(0)" i.e., string.
-                if context.lower().startswith('eia('):
-                    index = int(context[4:-1])
-                    mxnet_context.append(mx.eia(index))
-                elif context.lower().startswith('gpu('):
-                    index = int(context[4:-1])
-                    mxnet_context.append(mx.gpu(index))
-                elif context.lower() in mx.Context.devstr2type:
-                    mxnet_context.append(mx.Context(context.lower()))
-                else:
-                    raise ValueError("Invalid MXNet context provided - ", context)
-            else:
-                # If user has provided a list.
-                # List can be:
-                #   1. List of GPU IDs - [0, 1, 2, 3]
-                #   2. List of GPU context strings - ["gpu(0)", "gpu(1)"] or ["gpu0", "gpu1"]
-                #      Or, ["eia(0)", "eia(1)"]
-                for context_name in context:
-                    if isinstance(context_name, Number):
-                        mxnet_context.append(mx.gpu(context_name))
-                    elif context_name.startswith('cpu'):
-                        mxnet_context.append(mx.cpu())
-                    elif context_name.startswith('gpu('):
-                        index = int(context_name[4:-1])
-                        mxnet_context.append(mx.gpu(index))
-                    elif context_name.startswith('gpu'):
-                        index = int(context_name[3:])
-                        mxnet_context.append(mx.gpu(index))
-                    elif context_name.startswith('eia('):
-                        index = int(context_name[4:-1])
-                        mxnet_context.append(mx.eia(index))
-                    elif context_name.startswith('eia'):
-                        index = int(context_name[3:])
-                        mxnet_context.append(mx.eia(index))
-                    else:
-                        raise ValueError("Invalid MXNet context provided - ", context)
-
-            return mxnet_context
-
         def set_mxnet_context(self, context):
             """Sets the mxnet context for the current Model.
 
@@ -5723,7 +5714,7 @@ def get_model():
                                      'call `multi_gpu_model` with `gpus >= 2`. '
                                      'Received: `gpus=%d`' % context)
 
-            self._context = self.get_mxnet_context(context)
+            self._context = _get_mxnet_context(context)
 
     return Model
 

--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -290,7 +290,7 @@ class Network(Layer):
         for layer in self._output_layers:
             self.output_names.append(layer.name)
 
-    def _init_subclassed_network(self, name=None):
+    def _init_subclassed_network(self, name=None, **kwargs):
         self._base_init(name=name)
         self._is_graph_network = False
         self._expects_training_arg = has_arg(self.call, 'training')

--- a/tests/keras/backend/mxnet_context_test.py
+++ b/tests/keras/backend/mxnet_context_test.py
@@ -62,6 +62,10 @@ class TestMXNetContext(object):
         model.fit(self.x_train, self.y_train,
                   batch_size=self.batch_size,
                   epochs=self.epochs)
+        if len(self.gpus) > 0:
+            assert model._context == [mx.gpu(self.gpus[-1])]
+        else:
+            assert model._context == [mx.cpu()]
 
     def test_context_compile(self):
         model = self._get_model()
@@ -73,6 +77,10 @@ class TestMXNetContext(object):
         model.fit(self.x_train, self.y_train,
                   batch_size=self.batch_size,
                   epochs=self.epochs)
+        if len(self.gpus) > 0:
+            assert model._context == [mx.gpu(self.gpus[-1])]
+        else:
+            assert model._context == [mx.cpu()]
 
     def test_set_mxnet_context(self):
         model = self._get_model()
@@ -84,6 +92,10 @@ class TestMXNetContext(object):
         model.fit(self.x_train, self.y_train,
                   batch_size=self.batch_size,
                   epochs=self.epochs)
+        if len(self.gpus) > 0:
+            assert model._context == [mx.gpu(self.gpus[-1])]
+        else:
+            assert model._context == [mx.cpu()]
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/keras/backend/mxnet_context_test.py
+++ b/tests/keras/backend/mxnet_context_test.py
@@ -1,22 +1,12 @@
-import warnings
-
+import mxnet as mx
 import pytest
+
 import keras
 from keras import backend as K
 from keras.datasets import mnist
-from keras.models import Sequential
 from keras.layers import Dense, Dropout
+from keras.models import Sequential
 from keras.optimizers import RMSprop
-import mxnet as mx
-
-BACKEND = None
-
-try:
-    from keras.backend import mxnet_backend as KMX
-    BACKEND = KMX
-except ImportError:
-    KMX = None
-    warnings.warn('Could not import the MXNet backend')
 
 pytestmark = pytest.mark.skipif(K.backend() != 'mxnet',
                                 reason='Testing MXNet context supports only for MXNet backend')
@@ -25,7 +15,7 @@ pytestmark = pytest.mark.skipif(K.backend() != 'mxnet',
 class TestMXNetContext(object):
     batch_size = 128
     num_classes = 10
-    epochs = 1
+    epochs = 2
 
     (x_train, y_train), (x_test, y_test) = mnist.load_data()
 

--- a/tests/keras/backend/mxnet_context_test.py
+++ b/tests/keras/backend/mxnet_context_test.py
@@ -21,6 +21,7 @@ except ImportError:
 pytestmark = pytest.mark.skipif(K.backend() != 'mxnet',
                                 reason='Testing MXNet context supports only for MXNet backend')
 
+
 class TestMXNetContext(object):
     batch_size = 128
     num_classes = 10

--- a/tests/keras/backend/mxnet_context_test.py
+++ b/tests/keras/backend/mxnet_context_test.py
@@ -1,0 +1,88 @@
+import warnings
+
+import pytest
+import keras
+from keras import backend as K
+from keras.datasets import mnist
+from keras.models import Sequential
+from keras.layers import Dense, Dropout
+from keras.optimizers import RMSprop
+import mxnet as mx
+
+BACKEND = None
+
+try:
+    from keras.backend import mxnet_backend as KMX
+    BACKEND = KMX
+except ImportError:
+    KMX = None
+    warnings.warn('Could not import the MXNet backend')
+
+pytestmark = pytest.mark.skipif(K.backend() != 'mxnet',
+                                reason='Testing MXNet context supports only for MXNet backend')
+
+class TestMXNetContext(object):
+    batch_size = 128
+    num_classes = 10
+    epochs = 1
+
+    (x_train, y_train), (x_test, y_test) = mnist.load_data()
+
+    x_train = x_train.reshape(60000, 784)[:500]
+    x_train = x_train.astype('float32')
+    x_train /= 255
+    y_train = keras.utils.to_categorical(y_train[:500], num_classes)
+    gpus = mx.test_utils.list_gpus()
+    if len(gpus) > 0:
+        context = 'gpu(%d)' % gpus[-1]
+    else:
+        context = 'cpu'
+
+    def _get_model(self):
+        model = Sequential()
+        model.add(Dense(512, activation='relu', input_shape=(784,)))
+        model.add(Dropout(0.2))
+        model.add(Dense(512, activation='relu'))
+        model.add(Dropout(0.2))
+        model.add(Dense(self.num_classes, activation='softmax'))
+        return model
+
+    def test_context_model(self):
+        model = Sequential(context=self.context)
+        model.add(Dense(512, activation='relu', input_shape=(784,)))
+        model.add(Dropout(0.2))
+        model.add(Dense(512, activation='relu'))
+        model.add(Dropout(0.2))
+        model.add(Dense(self.num_classes, activation='softmax'))
+        model.compile(loss='categorical_crossentropy',
+                      optimizer=RMSprop(),
+                      metrics=['accuracy'])
+
+        model.fit(self.x_train, self.y_train,
+                  batch_size=self.batch_size,
+                  epochs=self.epochs)
+
+    def test_context_compile(self):
+        model = self._get_model()
+        model.compile(loss='categorical_crossentropy',
+                      optimizer=RMSprop(),
+                      metrics=['accuracy'],
+                      context=self.context)
+
+        model.fit(self.x_train, self.y_train,
+                  batch_size=self.batch_size,
+                  epochs=self.epochs)
+
+    def test_set_mxnet_context(self):
+        model = self._get_model()
+        model.set_mxnet_context(self.context)
+        model.compile(loss='categorical_crossentropy',
+                      optimizer=RMSprop(),
+                      metrics=['accuracy'])
+
+        model.fit(self.x_train, self.y_train,
+                  batch_size=self.batch_size,
+                  epochs=self.epochs)
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
### Summary
fix https://github.com/awslabs/keras-apache-mxnet/issues/251

This PR fix it, and added the following:

1. set MXNet context during Model class initialization using context kwargs
2. set MXNet context during model.compile() through context kwargs
3. set MXNet context using model.set_mxnet_context(context)

context supports single context or list of context, for example `'cpu'` or `'gpu(0)'` or `['gpu(1)', 'gpu(2)']`

Added tests at: `tests/keras/backend/mxnet_context_test.py`

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n]
