### PR TITLE
fix batchnorm freeze mean and var

### DIFF
--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -1996,7 +1996,8 @@ def batch_normalization(x, mean, var, beta, gamma, epsilon=1e-3):
 
 
 @keras_mxnet_symbol
-def mxnet_batchnorm(x, gamma, beta, moving_mean, moving_var, momentum=0.9, axis=1, epsilon=1e-3):
+def mxnet_batchnorm(x, gamma, beta, moving_mean, moving_var, momentum=0.9, axis=1, epsilon=1e-3,
+                    use_global_stats=False):
     """Apply native  MXNet batch normalization on x with given moving_mean,
     moving_var, beta and gamma.
 
@@ -2030,8 +2031,8 @@ def mxnet_batchnorm(x, gamma, beta, moving_mean, moving_var, momentum=0.9, axis=
                       'Provided - `' + str(axis) + '`. Performance can be significantly lower!', stacklevel=2)
 
     return KerasSymbol(
-        mx.sym.BatchNorm(x, gamma, beta, moving_mean,
-                         moving_var, momentum=momentum, axis=axis, eps=epsilon))
+        mx.sym.BatchNorm(x, gamma, beta, moving_mean, moving_var, momentum=momentum, axis=axis, eps=epsilon,
+                         use_global_stats=use_global_stats))
 
 
 # SHAPE OPERATIONS

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -160,7 +160,8 @@ class BatchNormalization(Layer):
         # This is functional for now, however, needs to be revisited to do it in native Keras way.
         if K.backend() == 'mxnet':
             return K.mxnet_batchnorm(inputs, self.gamma, self.beta, self.moving_mean, self.moving_variance,
-                                     self.momentum, axis=self.axis, epsilon=self.epsilon, use_global_stats=self.trainable)
+                                     self.momentum, axis=self.axis, epsilon=self.epsilon,
+                                     use_global_stats=self.trainable)
 
         input_shape = K.int_shape(inputs)
         # Prepare broadcasting shape.

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -160,7 +160,7 @@ class BatchNormalization(Layer):
         # This is functional for now, however, needs to be revisited to do it in native Keras way.
         if K.backend() == 'mxnet':
             return K.mxnet_batchnorm(inputs, self.gamma, self.beta, self.moving_mean, self.moving_variance,
-                                     self.momentum, axis=self.axis, epsilon=self.epsilon)
+                                     self.momentum, axis=self.axis, epsilon=self.epsilon, use_global_stats=self.trainable)
 
         input_shape = K.int_shape(inputs)
         # Prepare broadcasting shape.

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -161,7 +161,7 @@ class BatchNormalization(Layer):
         if K.backend() == 'mxnet':
             return K.mxnet_batchnorm(inputs, self.gamma, self.beta, self.moving_mean, self.moving_variance,
                                      self.momentum, axis=self.axis, epsilon=self.epsilon,
-                                     use_global_stats=self.trainable)
+                                     use_global_stats=not self.trainable)
 
         input_shape = K.int_shape(inputs)
         # Prepare broadcasting shape.

--- a/tests/keras/backend/mxnet_operator_test.py
+++ b/tests/keras/backend/mxnet_operator_test.py
@@ -28,13 +28,14 @@ class TestMXNetOperator(object):
         model = Model(inputs=[x], outputs=[y])
         model.compile(loss='binary_crossentropy', optimizer='sgd')
         model.fit(data, label, batch_size=5, epochs=10, verbose=1)
-        path = '/tmp/test_model.hdf5'
-        model.save(path)
-        loaded = load_model(path)
         free_layers = {'y'}
-        for layer in loaded.layers:
+        for layer in model.layers:
             if layer.name not in free_layers:
                 layer.trainable = False
+        path = '/tmp/test_model.hdf5'
+        model.save(path)
+
+        loaded = load_model(path)
         loaded.compile(loss='binary_crossentropy', optimizer='sgd')
 
         loaded.fit(data, label, batch_size=5, epochs=10, verbose=1)

--- a/tests/keras/backend/mxnet_operator_test.py
+++ b/tests/keras/backend/mxnet_operator_test.py
@@ -1,0 +1,53 @@
+import pytest
+
+import numpy as np
+from keras import backend as K
+from keras import Model
+from keras.layers import Input, Dense, Activation, BatchNormalization
+from keras.models import load_model
+
+pytestmark = pytest.mark.skipif(K.backend() != 'mxnet',
+                                reason='Testing MXNet context supports only for MXNet backend')
+
+
+class TestMXNetOperator(object):
+
+    def test_batchnorm_freeze(self):
+        data = np.array([
+            [i, i ** 2, i + 2] for i in range(10)
+        ])
+        label = np.array([
+            [i % 2] for i in range(10)
+        ])
+        x = Input(shape=(3,), name='x')
+        f = Dense(10, name='h1')(x)
+        f = BatchNormalization(name='bn1')(f)
+        f = Activation('relu', name='r1')(f)
+        y = Dense(1, name='y')(f)
+
+        model = Model(inputs=[x], outputs=[y])
+        model.compile(loss='binary_crossentropy', optimizer='sgd')
+        model.fit(data, label, batch_size=5, epochs=10, verbose=1)
+        path = '/tmp/test_model.hdf5'
+        model.save(path)
+        loaded = load_model(path)
+        free_layers = {'y'}
+        for layer in loaded.layers:
+            if layer.name not in free_layers:
+                layer.trainable = False
+        loaded.compile(loss='binary_crossentropy', optimizer='sgd')
+
+        loaded.fit(data, label, batch_size=5, epochs=10, verbose=1)
+        for l1, l2 in zip(model.layers, loaded.layers):
+            l1_weights = l1.get_weights()
+            l2_weights = l2.get_weights()
+            check = True
+            for idx in range(len(l1_weights)):
+                check &= np.allclose(l1_weights[idx], l2_weights[idx])
+            # only the last layers have different weights
+            if l1.name != 'y':
+                assert check is True
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
As per user feedback, Keras-MXNet was not able to freeze the running mean and var weights during fine tune.

This PR fix the bug and added unit test
Reference:
https://discuss.mxnet.io/t/how-freeze-batchnorm-layer-in-symbolblock/3949