### PR TITLE
fix kwargs and add comments

### DIFF
--- a/keras/engine/network.py
+++ b/keras/engine/network.py
@@ -95,7 +95,7 @@ class Network(Layer):
             # Subclassed network
             self._init_subclassed_network(**kwargs)
 
-    def _base_init(self, name=None):
+    def _base_init(self, name=None, **kwargs):
         # The following are implemented as property functions:
         # self.trainable_weights
         # self.non_trainable_weights
@@ -136,7 +136,7 @@ class Network(Layer):
         self._outbound_nodes = []
         self._inbound_nodes = []
 
-    def _init_graph_network(self, inputs, outputs, name=None):
+    def _init_graph_network(self, inputs, outputs, name=None, **kwargs):
         self._uses_inputs_arg = True
         # Normalize and set self.inputs, self.outputs.
         self.inputs = to_list(inputs, allow_tuple=True)
@@ -186,7 +186,7 @@ class Network(Layer):
                                  'the output of a Keras `Layer` '
                                  '(thus holding past layer metadata). '
                                  'Found: ' + str(x))
-        self._base_init(name=name)
+        self._base_init(name=name, **kwargs)
         self._compute_previous_mask = (
             has_arg(self.call, 'mask') or
             hasattr(self, 'compute_mask'))
@@ -291,7 +291,7 @@ class Network(Layer):
             self.output_names.append(layer.name)
 
     def _init_subclassed_network(self, name=None, **kwargs):
-        self._base_init(name=name)
+        self._base_init(name=name, **kwargs)
         self._is_graph_network = False
         self._expects_training_arg = has_arg(self.call, 'training')
         self._uses_inputs_arg = has_arg(self.call, 'inputs')

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -158,6 +158,8 @@ class BatchNormalization(Layer):
         # MXNet Backend calculates moving mean and moving variance in batch_norm operation directly.
         # Hence, calling native mxnet batchnorm.
         # This is functional for now, however, needs to be revisited to do it in native Keras way.
+        # to freeze BatchNorm layer, pass `trainable=False` during layer construction
+        # for more info refer to issue: https://github.com/awslabs/keras-apache-mxnet/issues/23
         if K.backend() == 'mxnet':
             return K.mxnet_batchnorm(inputs, self.gamma, self.beta, self.moving_mean, self.moving_variance,
                                      self.momentum, axis=self.axis, epsilon=self.epsilon,


### PR DESCRIPTION
### Summary
1. Fix kwargs
In https://github.com/awslabs/keras-apache-mxnet/pull/250, I added `**kwargs` in `_init_subclassed_network` inorder to fix MXNet context problem, and it's not enough.

This PR brings more `**kwargs` in Keras front end to fix `**kwargs` not passed along in subsequent `_base_init `  method.

These changed are already made in official upstream Keras front end, and will be updated during next merge.

2. Updated comments to properly fix moving mean and var for BatchNorm layer

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n]
