### PR TITLE
Fix axis error in normalization layer when loading model from tf backend saved h5

### DIFF
--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -93,7 +93,7 @@ class BatchNormalization(Layer):
         if axis == -1 and K.image_data_format() == 'channels_first' and K.backend() == 'mxnet':
             self.axis = 1
         else:
-            self.axis = axis[-1] if isinstance(axis, list) else axis
+            self.axis = axis[0] if isinstance(axis, list) and len(axis) == 1 else axis
 
     def build(self, input_shape):
         dim = input_shape[self.axis]

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -93,7 +93,7 @@ class BatchNormalization(Layer):
         if axis == -1 and K.image_data_format() == 'channels_first' and K.backend() == 'mxnet':
             self.axis = 1
         else:
-            self.axis = axis
+            self.axis = axis if isinstance(axis, int) else axis[-1]
 
     def build(self, input_shape):
         dim = input_shape[self.axis]

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -93,7 +93,7 @@ class BatchNormalization(Layer):
         if axis == -1 and K.image_data_format() == 'channels_first' and K.backend() == 'mxnet':
             self.axis = 1
         else:
-            self.axis = axis if isinstance(axis, int) else axis[-1]
+            self.axis = axis[-1] if isinstance(axis, list) else axis
 
     def build(self, input_shape):
         dim = input_shape[self.axis]

--- a/tests/keras/backend/mxnet_tf_model_test.py
+++ b/tests/keras/backend/mxnet_tf_model_test.py
@@ -1,0 +1,49 @@
+import pytest
+
+import tempfile
+from keras import backend as K
+from keras.layers import Dense, BatchNormalization
+from keras.models import load_model, Sequential
+from keras.backend import tensorflow_backend as KTF
+import warnings
+
+pytestmark = pytest.mark.skipif(K.backend() != "mxnet",
+        reason="Testing MXNet context supports only for MXNet backend")
+
+
+class TestMXNetTfModel(object):
+    def test_batchnorm_layer_reload(self):
+        # Save a tf backend keras h5 model
+        tf_model = KTF.tf.keras.models.Sequential([
+            KTF.tf.keras.layers.Dense(10, kernel_initializer="zeros"),
+            KTF.tf.keras.layers.BatchNormalization(),
+        ])
+        tf_model.build(input_shape=(1, 10))
+        _, fname = tempfile.mkstemp(".h5")
+        tf_model.save(fname)
+
+        # Load from MXNet backend keras
+        try:
+            mx_model = load_model(fname, compile=False)
+        except TypeError:
+            warnings.warn("Could not reload from tensorflow backend saved model.")
+            assert False
+
+        # Retest with mxnet backend keras save + load
+        mx_model_2 = Sequential([
+            Dense(10, kernel_initializer="zeros"),
+            BatchNormalization(),
+        ])
+        mx_model_2.build(input_shape=(1, 10))
+        _, fname = tempfile.mkstemp(".h5")
+        mx_model_2.save(fname)
+
+        try:
+            mx_model_3 = load_model(fname, compile=False)
+        except TypeError:
+            warnings.warn("Could not reload from MXNet backend saved model.")
+            assert False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Fix axis error in normalization layer when loading model from tf backend saved h5

### Summary
When loading model saved by tensorflow backend keras h5 file, met an error:
```sh
/opt/anaconda3/lib/python3.7/site-packages/keras/layers/normalization.py in build(self, input_shape)
     98
     99     def build(self, input_shape):
--> 100         dim = input_shape[self.axis]
    101         print(input_shape, self.axis, dim)
    102         if dim is None
TypeError: tuple indices must be integers or slices, not list
```
I write a little demo to reproduce it:
- Save a tensorflow backend keras h5 model file:
```py
from tensorflow import keras
mm = keras.models.Sequential([
    keras.layers.Dense(10, kernel_initializer="zeros"),
    keras.layers.BatchNormalization()])
mm.build(input_shape=(1, 10))
mm.summary()
mm.layers[-1].axis  # This is `1` if backend is MXNet, and data_format is 'channels_first'
# ListWrapper([1])
mm.save('mm.h5')
```
- Load from MXNet backend keras:
```py
# $ KERAS_BACKEND='mxnet' ipython
import keras
# Using MXNet backend
mm = keras.models.load_model('mm.h5', compile=False)
# /opt/anaconda3/lib/python3.7/site-packages/keras/layers/normalization.py in build(self, input_shape)
# TypeError: tuple indices must be integers or slices, not list
```
### Related Issues
None

### PR Overview
It seems in tensorflow backend keras, `axis` in `BatchNormalization` is a list, so I add an `isinstance` test to the `self.axis` init. Then the `load_model` function passed.

- [y] This PR requires new unit tests [y/n] (make sure tests are included)
- [n] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [y] This PR is backwards compatible [y/n]
- [n] This PR changes the current API [y/n]
